### PR TITLE
Many Features

### DIFF
--- a/app/src/main/java/com/ivor/ivormusic/MainActivity.kt
+++ b/app/src/main/java/com/ivor/ivormusic/MainActivity.kt
@@ -3,6 +3,7 @@ package com.ivor.ivormusic
 import android.content.Intent
 import android.os.Build
 import android.os.Bundle
+import android.view.WindowManager
 import androidx.activity.ComponentActivity
 import androidx.activity.compose.setContent
 import androidx.activity.enableEdgeToEdge
@@ -135,6 +136,15 @@ class MainActivity : ComponentActivity() {
         requestedOrientation = android.content.pm.ActivityInfo.SCREEN_ORIENTATION_PORTRAIT
 
         enableEdgeToEdge()
+        // Treat camera cutouts as usable edge-to-edge space everywhere. The
+        // old video-only toggle restored DEFAULT on exit, which could
+        // letterbox the rest of the app for the remainder of the session.
+        // Controls still handle status/navigation bars independently; only
+        // the notch-specific exclusion is deliberately ignored.
+        window.attributes = window.attributes.also {
+            it.layoutInDisplayCutoutMode =
+                WindowManager.LayoutParams.LAYOUT_IN_DISPLAY_CUTOUT_MODE_ALWAYS
+        }
 
         setContent {
             val themeViewModel: ThemeViewModel = viewModel()

--- a/app/src/main/java/com/ivor/ivormusic/MainActivity.kt
+++ b/app/src/main/java/com/ivor/ivormusic/MainActivity.kt
@@ -539,6 +539,7 @@ fun MusicApp(
     val isMusicPlaying by playerViewModel.isPlaying.collectAsState()
     val isVideoPlaying by videoPlayerViewModel.isPlaying.collectAsState()
     val isShortsPlaying by shortsPlayerViewModel.isPlaying.collectAsState()
+    val pendingSongDownload by playerViewModel.pendingSongDownload.collectAsState()
     androidx.compose.runtime.LaunchedEffect(isMusicPlaying) {
         if (isMusicPlaying) {
             videoPlayerViewModel.pause()
@@ -1054,6 +1055,18 @@ fun MusicApp(
             hiddenActions = shortsHiddenActions,
             onOpenChannel = openChannel
         )
+
+        // One confirmation host covers the player controls and every song
+        // options sheet. Download requests carry the chosen song through the
+        // PlayerViewModel so a non-playing row works even when no mini player
+        // exists to host UI of its own.
+        pendingSongDownload?.let {
+            com.ivor.ivormusic.ui.downloads.SongDownloadSheet(
+                song = it,
+                onConfirm = playerViewModel::confirmPendingSongDownload,
+                onDismiss = playerViewModel::dismissPendingSongDownload
+            )
+        }
 
         // Undo for "don't recommend", app-wide and last in the stack.
         //

--- a/app/src/main/java/com/ivor/ivormusic/MainActivity.kt
+++ b/app/src/main/java/com/ivor/ivormusic/MainActivity.kt
@@ -507,6 +507,20 @@ fun MusicApp(
     val videoPlayerViewModel: com.ivor.ivormusic.ui.video.VideoPlayerViewModel = viewModel()
     val shortsPlayerViewModel: com.ivor.ivormusic.ui.shorts.ShortsPlayerViewModel = viewModel()
 
+    // Changing content modes is a clean hand-off: no player from the previous
+    // mode should remain visible or continue playing after the switch. Route
+    // every mode toggle through the same close actions used by the players'
+    // own dismiss buttons, while ignoring callbacks that repeat the current
+    // value (including preference restoration during composition).
+    val switchPlaybackMode: (Boolean) -> Unit = { nextVideoMode ->
+        if (nextVideoMode != videoMode) {
+            playerViewModel.clearPlayer()
+            videoPlayerViewModel.closePlayer()
+            shortsPlayerViewModel.close()
+            onVideoModeToggle(nextVideoMode)
+        }
+    }
+
     // A live broadcast that turned up in the Shorts feed. The Shorts player
     // cannot present one honestly (no chat, and a seek bar for a duration that
     // does not exist), so it closes itself and the stream reopens here, where
@@ -671,7 +685,7 @@ fun MusicApp(
                     ambientBackground = ambientBackground,
                     onAmbientBackgroundToggle = onAmbientBackgroundToggle,
                     videoMode = videoMode,
-                    onVideoModeToggle = onVideoModeToggle,
+                    onVideoModeToggle = switchPlaybackMode,
                     homeModeToggleEnabled = homeModeToggleEnabled,
                     onHomeModeToggleEnabledChange = onHomeModeToggleEnabledChange,
                     shortsEnabled = shortsEnabled,
@@ -730,7 +744,7 @@ fun MusicApp(
                     ambientBackground = ambientBackground,
                     playerArtworkColors = playerArtworkColors,
                     videoMode = videoMode,
-                    onVideoModeToggle = onVideoModeToggle,
+                    onVideoModeToggle = switchPlaybackMode,
                     showModeToggle = homeModeToggleEnabled,
                     playerStyle = playerStyle,
                     onPlayerStyleChange = onPlayerStyleChange,
@@ -767,7 +781,7 @@ fun MusicApp(
                     playerArtworkColors = playerArtworkColors,
                     onPlayerArtworkColorsToggle = onPlayerArtworkColorsToggle,
                     videoMode = videoMode,
-                    onVideoModeToggle = onVideoModeToggle,
+                    onVideoModeToggle = switchPlaybackMode,
                     homeModeToggleEnabled = homeModeToggleEnabled,
                     onHomeModeToggleChange = onHomeModeToggleEnabledChange,
                     spotlightHome = spotlightHome,

--- a/app/src/main/java/com/ivor/ivormusic/data/DownloadRepository.kt
+++ b/app/src/main/java/com/ivor/ivormusic/data/DownloadRepository.kt
@@ -738,6 +738,7 @@ class DownloadRepository private constructor(private val context: Context) {
             val song = request.song ?: return@withContext false
             val pendingTargets = mutableListOf<Uri>()
             var audioTemp: File? = null
+            var taggedAudioTemp: File? = null
             var artworkTemp: File? = null
             updateProgress(request, 0.02f, DownloadStatus.DOWNLOADING)
 
@@ -777,12 +778,28 @@ class DownloadRepository private constructor(private val context: Context) {
 
                     ensureActive()
                     updateProgress(request, 0.88f, DownloadStatus.DOWNLOADING)
-                    DownloadedAudioMetadata.write(
-                        audioFile = audioTemp!!,
+                    val metadataCopy = DownloadedAudioMetadata.writeCopy(
+                        sourceAudio = audioTemp!!,
+                        tempDirectory = context.cacheDir,
                         song = song,
                         artworkFile = artworkTemp,
                         lyrics = lyrics
                     )
+                    taggedAudioTemp = metadataCopy.getOrNull()
+                    val audioToPublish = metadataCopy.getOrElse { error ->
+                        // Portable tags are enrichment, not the song itself.
+                        // In particular, jaudiotagger cannot grow the metadata
+                        // atom in every YouTube M4A layout. Keep the untouched
+                        // download and publish the companion artwork/lyrics
+                        // instead of transferring the same audio three times.
+                        KLog.w(
+                            TAG,
+                            "Portable metadata unavailable for ${song.title}; " +
+                                "publishing untouched audio",
+                            error
+                        )
+                        audioTemp!!
+                    }
 
                     ensureActive()
                     updateProgress(request, 0.92f, DownloadStatus.DOWNLOADING)
@@ -795,7 +812,7 @@ class DownloadRepository private constructor(private val context: Context) {
                     val audioTarget = storage.createPending(audioName, DownloadMediaType.MUSIC)
                         ?: throw java.io.IOException("Could not create audio storage entry")
                     pendingTargets += audioTarget
-                    copyToPending(audioTemp!!, audioTarget)
+                    copyToPending(audioToPublish, audioTarget)
 
                     val artworkTarget = artworkTemp?.let { cover ->
                         val name = storage.buildMusicCompanionFileName(
@@ -869,6 +886,7 @@ class DownloadRepository private constructor(private val context: Context) {
                 throw e
             } finally {
                 audioTemp?.delete()
+                taggedAudioTemp?.delete()
                 artworkTemp?.delete()
                 activeDownloadCalls.remove(request.id)
             }

--- a/app/src/main/java/com/ivor/ivormusic/data/DownloadRepository.kt
+++ b/app/src/main/java/com/ivor/ivormusic/data/DownloadRepository.kt
@@ -523,6 +523,32 @@ class DownloadRepository private constructor(private val context: Context) {
     }
 
     /**
+     * Resolve the exact byte length of the audio stream that would be selected
+     * for [song]. Artwork, lyrics and metadata are deliberately not guessed;
+     * the confirmation UI labels this as an estimate because those small
+     * companions are fetched only while the real download runs.
+     */
+    suspend fun estimateSongDownloadBytes(song: Song): Long? {
+        val url = youtubeRepository.getDownloadAudioStreamUrl(song.id).getOrNull()
+            ?: return null
+        return remoteMediaSize(url)
+    }
+
+    /**
+     * Exact media bytes for a downloadable quality. Adaptive video is the sum
+     * of its separate video and audio files; a progressive stream is one file.
+     * Returning null when either half is unknown avoids presenting a confident
+     * underestimate in the confirmation sheet.
+     */
+    suspend fun estimateVideoDownloadBytes(quality: VideoQuality): Long? = coroutineScope {
+        val urls = listOfNotNull(quality.url, quality.audioUrl).distinct()
+        val sizes = urls.map { url -> async { remoteMediaSize(url) } }.map { it.await() }
+        sizes.takeIf { values -> values.isNotEmpty() && values.all { it != null } }
+            ?.sumOf { it ?: 0L }
+            ?.takeIf { it > 0L }
+    }
+
+    /**
      * Queue several videos at once with one quality cap for the batch.
      *
      * Live broadcasts only expose an HLS manifest and cannot be remuxed by the
@@ -1093,6 +1119,32 @@ class DownloadRepository private constructor(private val context: Context) {
 
         if (totalBytes > 0 && position < totalBytes) {
             throw java.io.IOException("Truncated: $position/$totalBytes")
+        }
+    }
+
+    /**
+     * Ask googlevideo for one bounded byte and read the total from
+     * Content-Range. This keeps the size preview cheap and preserves the
+     * repository-wide rule that media URLs are never fetched open-ended.
+     */
+    private suspend fun remoteMediaSize(url: String): Long? = withContext(Dispatchers.IO) {
+        val response = runCatching {
+            client.newCall(
+                Request.Builder()
+                    .url(url)
+                    .header("User-Agent", YouTubeRepository.uaForPlaybackUri(Uri.parse(url)))
+                    .header("Range", "bytes=0-0")
+                    .build()
+            ).execute()
+        }.getOrNull() ?: return@withContext null
+
+        response.use {
+            if (!it.isSuccessful) return@withContext null
+            if (it.code == 206) {
+                parseContentRangeTotal(it.header("Content-Range"))
+            } else {
+                it.body?.contentLength()?.takeIf { length -> length > 0L }
+            }
         }
     }
 

--- a/app/src/main/java/com/ivor/ivormusic/data/DownloadedAudioMetadata.kt
+++ b/app/src/main/java/com/ivor/ivormusic/data/DownloadedAudioMetadata.kt
@@ -17,7 +17,31 @@ import java.util.Locale
  */
 internal object DownloadedAudioMetadata {
 
-    fun write(
+    /**
+     * Add portable tags without ever putting the downloaded media at risk.
+     *
+     * Some YouTube M4A layouts leave no free atom large enough for embedded
+     * artwork. jaudiotagger then shifts the MP4 data and can reject its own
+     * rewritten offsets. Performing that operation on the only downloaded
+     * copy made an otherwise playable song fail. The caller can now publish
+     * [sourceAudio] whenever this best-effort result fails.
+     */
+    fun writeCopy(
+        sourceAudio: File,
+        tempDirectory: File,
+        song: Song,
+        artworkFile: File?,
+        lyrics: String?
+    ): Result<File> = createMetadataCopy(sourceAudio, tempDirectory) { taggedCopy ->
+        write(
+            audioFile = taggedCopy,
+            song = song,
+            artworkFile = artworkFile,
+            lyrics = lyrics
+        )
+    }
+
+    private fun write(
         audioFile: File,
         song: Song,
         artworkFile: File?,
@@ -48,6 +72,27 @@ internal object DownloadedAudioMetadata {
     }
 
     private const val FRONT_COVER_PICTURE_TYPE = 3
+}
+
+/**
+ * Copy first, enrich second, and remove a rejected copy. Kept independent of
+ * jaudiotagger so the non-destructive fallback contract has a JVM unit test.
+ */
+internal fun createMetadataCopy(
+    sourceAudio: File,
+    tempDirectory: File,
+    writer: (File) -> Unit
+): Result<File> {
+    var taggedCopy: File? = null
+    return runCatching {
+        File.createTempFile("koda_tagged_", ".m4a", tempDirectory).also { copy ->
+            taggedCopy = copy
+            sourceAudio.copyTo(copy, overwrite = true)
+            writer(copy)
+        }
+    }.onFailure {
+        taggedCopy?.delete()
+    }
 }
 
 /**

--- a/app/src/main/java/com/ivor/ivormusic/data/ThemePreferences.kt
+++ b/app/src/main/java/com/ivor/ivormusic/data/ThemePreferences.kt
@@ -73,7 +73,7 @@ class ThemePreferences(context: Context) {
     val videoQualityMobile: StateFlow<String> = _videoQualityMobile.asStateFlow()
 
     private val _captionTextSize = MutableStateFlow(getCaptionTextSizePreference())
-    val captionTextSize: StateFlow<CaptionTextSize> = _captionTextSize.asStateFlow()
+    val captionTextSize: StateFlow<Float> = _captionTextSize.asStateFlow()
 
     private val _captionTextColor = MutableStateFlow(getCaptionTextColorPreference())
     val captionTextColor: StateFlow<CaptionTextColor> = _captionTextColor.asStateFlow()
@@ -905,10 +905,8 @@ class ThemePreferences(context: Context) {
         _videoQualityMobile.value = quality
     }
 
-    private fun getCaptionTextSizePreference(): CaptionTextSize =
-        prefs.getString(KEY_CAPTION_TEXT_SIZE, null)
-            ?.let { stored -> CaptionTextSize.entries.firstOrNull { it.name == stored } }
-            ?: CaptionTextSize.MEDIUM
+    private fun getCaptionTextSizePreference(): Float =
+        captionTextScaleFromStored(prefs.all[KEY_CAPTION_TEXT_SIZE])
 
     private fun getCaptionTextColorPreference(): CaptionTextColor =
         prefs.getString(KEY_CAPTION_TEXT_COLOR, null)
@@ -920,9 +918,10 @@ class ThemePreferences(context: Context) {
             ?.let { stored -> CaptionBackground.entries.firstOrNull { it.name == stored } }
             ?: CaptionBackground.TRANSLUCENT
 
-    fun setCaptionTextSize(size: CaptionTextSize) {
-        prefs.edit().putString(KEY_CAPTION_TEXT_SIZE, size.name).apply()
-        _captionTextSize.value = size
+    fun setCaptionTextSize(size: Float) {
+        val safeSize = size.coerceIn(CAPTION_TEXT_SCALE_MIN, CAPTION_TEXT_SCALE_MAX)
+        prefs.edit().putFloat(KEY_CAPTION_TEXT_SIZE, safeSize).apply()
+        _captionTextSize.value = safeSize
     }
 
     fun setCaptionTextColor(color: CaptionTextColor) {
@@ -1383,12 +1382,24 @@ class ThemePreferences(context: Context) {
     }
 }
 
-/** Persisted names are user settings and must not be renamed. */
-enum class CaptionTextSize {
-    SMALL,
-    MEDIUM,
-    LARGE
-}
+const val CAPTION_TEXT_SCALE_MIN = 0.75f
+const val CAPTION_TEXT_SCALE_DEFAULT = 1f
+
+/** Twice the former Large preset (1.25x), for high-density displays. */
+const val CAPTION_TEXT_SCALE_MAX = 2.5f
+
+/**
+ * Read both the new float and the three names written by Koda 4.6. Keeping the
+ * conversion outside SharedPreferences makes the migration deterministic and
+ * unit-testable without an Android Context.
+ */
+internal fun captionTextScaleFromStored(stored: Any?): Float = when (stored) {
+    is Number -> stored.toFloat()
+    "SMALL" -> CAPTION_TEXT_SCALE_MIN
+    "MEDIUM" -> CAPTION_TEXT_SCALE_DEFAULT
+    "LARGE" -> 1.25f
+    else -> CAPTION_TEXT_SCALE_DEFAULT
+}.coerceIn(CAPTION_TEXT_SCALE_MIN, CAPTION_TEXT_SCALE_MAX)
 
 /** Video-safe foreground choices, paired with the caption background. */
 enum class CaptionTextColor {

--- a/app/src/main/java/com/ivor/ivormusic/data/ThemePreferences.kt
+++ b/app/src/main/java/com/ivor/ivormusic/data/ThemePreferences.kt
@@ -72,6 +72,15 @@ class ThemePreferences(context: Context) {
     private val _videoQualityMobile = MutableStateFlow(getVideoQualityMobilePreference())
     val videoQualityMobile: StateFlow<String> = _videoQualityMobile.asStateFlow()
 
+    private val _captionTextSize = MutableStateFlow(getCaptionTextSizePreference())
+    val captionTextSize: StateFlow<CaptionTextSize> = _captionTextSize.asStateFlow()
+
+    private val _captionTextColor = MutableStateFlow(getCaptionTextColorPreference())
+    val captionTextColor: StateFlow<CaptionTextColor> = _captionTextColor.asStateFlow()
+
+    private val _captionBackground = MutableStateFlow(getCaptionBackgroundPreference())
+    val captionBackground: StateFlow<CaptionBackground> = _captionBackground.asStateFlow()
+
     private val _musicQualityWifi = MutableStateFlow(getMusicQualityWifiPreference())
     val musicQualityWifi: StateFlow<String> = _musicQualityWifi.asStateFlow()
 
@@ -169,6 +178,9 @@ class ThemePreferences(context: Context) {
             KEY_SHORTS_HIDDEN_ACTIONS -> _shortsHiddenActions.value = getShortsHiddenActionsPreference()
             KEY_VIDEO_QUALITY_WIFI -> _videoQualityWifi.value = getVideoQualityWifiPreference()
             KEY_VIDEO_QUALITY_MOBILE -> _videoQualityMobile.value = getVideoQualityMobilePreference()
+            KEY_CAPTION_TEXT_SIZE -> _captionTextSize.value = getCaptionTextSizePreference()
+            KEY_CAPTION_TEXT_COLOR -> _captionTextColor.value = getCaptionTextColorPreference()
+            KEY_CAPTION_BACKGROUND -> _captionBackground.value = getCaptionBackgroundPreference()
             KEY_MUSIC_QUALITY_WIFI -> _musicQualityWifi.value = getMusicQualityWifiPreference()
             KEY_MUSIC_QUALITY_MOBILE -> _musicQualityMobile.value = getMusicQualityMobilePreference()
             KEY_SPOTLIGHT_HOME -> _spotlightHome.value = getSpotlightHomePreference()
@@ -269,6 +281,9 @@ class ThemePreferences(context: Context) {
 
         private const val KEY_VIDEO_QUALITY_WIFI = "video_quality_wifi"
         private const val KEY_VIDEO_QUALITY_MOBILE = "video_quality_mobile"
+        private const val KEY_CAPTION_TEXT_SIZE = "caption_text_size"
+        private const val KEY_CAPTION_TEXT_COLOR = "caption_text_color"
+        private const val KEY_CAPTION_BACKGROUND = "caption_background"
 
         /** Sentinel meaning "highest available quality". */
         const val VIDEO_QUALITY_AUTO = "auto"
@@ -890,6 +905,36 @@ class ThemePreferences(context: Context) {
         _videoQualityMobile.value = quality
     }
 
+    private fun getCaptionTextSizePreference(): CaptionTextSize =
+        prefs.getString(KEY_CAPTION_TEXT_SIZE, null)
+            ?.let { stored -> CaptionTextSize.entries.firstOrNull { it.name == stored } }
+            ?: CaptionTextSize.MEDIUM
+
+    private fun getCaptionTextColorPreference(): CaptionTextColor =
+        prefs.getString(KEY_CAPTION_TEXT_COLOR, null)
+            ?.let { stored -> CaptionTextColor.entries.firstOrNull { it.name == stored } }
+            ?: CaptionTextColor.WHITE
+
+    private fun getCaptionBackgroundPreference(): CaptionBackground =
+        prefs.getString(KEY_CAPTION_BACKGROUND, null)
+            ?.let { stored -> CaptionBackground.entries.firstOrNull { it.name == stored } }
+            ?: CaptionBackground.TRANSLUCENT
+
+    fun setCaptionTextSize(size: CaptionTextSize) {
+        prefs.edit().putString(KEY_CAPTION_TEXT_SIZE, size.name).apply()
+        _captionTextSize.value = size
+    }
+
+    fun setCaptionTextColor(color: CaptionTextColor) {
+        prefs.edit().putString(KEY_CAPTION_TEXT_COLOR, color.name).apply()
+        _captionTextColor.value = color
+    }
+
+    fun setCaptionBackground(background: CaptionBackground) {
+        prefs.edit().putString(KEY_CAPTION_BACKGROUND, background.name).apply()
+        _captionBackground.value = background
+    }
+
     // ---------------- Subscriptions ----------------
 
     private fun getSubscriptionSourcePreference(): String =
@@ -1336,6 +1381,26 @@ class ThemePreferences(context: Context) {
         prefs.edit().putBoolean(KEY_ONBOARDING_COMPLETED, completed).apply()
         _onboardingCompleted.value = completed
     }
+}
+
+/** Persisted names are user settings and must not be renamed. */
+enum class CaptionTextSize {
+    SMALL,
+    MEDIUM,
+    LARGE
+}
+
+/** Video-safe foreground choices, paired with the caption background. */
+enum class CaptionTextColor {
+    WHITE,
+    YELLOW
+}
+
+/** Strength of the black caption plate drawn over the video frame. */
+enum class CaptionBackground {
+    NONE,
+    TRANSLUCENT,
+    SOLID
 }
 
 /**

--- a/app/src/main/java/com/ivor/ivormusic/data/VideoItem.kt
+++ b/app/src/main/java/com/ivor/ivormusic/data/VideoItem.kt
@@ -294,11 +294,12 @@ data class VideoChapter(
 )
 
 /**
- * A YouTube storyboard sprite used while scrubbing the video timeline.
+ * A frame source used while scrubbing the video timeline.
  *
- * NewPipe returns the sprite pages as part of the same extraction that resolves
- * playback, so this adds no second player request. [durationPerFrameMs] maps a
- * requested playback position to one cell inside one of [pageUrls].
+ * Online playback uses YouTube storyboard pages returned by NewPipe as part of
+ * stream extraction. Downloaded playback instead supplies [localVideoUri], so
+ * the UI can decode a bounded frame directly from the offline MP4 without a
+ * network request. Exactly one source is expected to be usable.
  */
 data class VideoSeekPreview(
     val pageUrls: List<String>,
@@ -308,15 +309,22 @@ data class VideoSeekPreview(
     val framesPerPageY: Int,
     val totalFrameCount: Int,
     val durationPerFrameMs: Int,
+    val localVideoUri: String? = null,
 ) {
+    val isLocal: Boolean
+        get() = !localVideoUri.isNullOrBlank()
+
     val isUsable: Boolean
+        get() = isLocal || isStoryboardUsable
+
+    private val isStoryboardUsable: Boolean
         get() = pageUrls.isNotEmpty() &&
             frameWidthPx > 0 && frameHeightPx > 0 &&
             framesPerPageX > 0 && framesPerPageY > 0 &&
             totalFrameCount > 0 && durationPerFrameMs > 0
 
     fun frameAt(positionMs: Long): VideoSeekPreviewFrame? {
-        if (!isUsable) return null
+        if (!isStoryboardUsable) return null
         val frameIndex = (positionMs.coerceAtLeast(0L) / durationPerFrameMs)
             .coerceAtMost((totalFrameCount - 1).toLong())
             .toInt()
@@ -330,6 +338,19 @@ data class VideoSeekPreview(
                 row = indexOnPage / framesPerPageX,
             )
         }
+    }
+
+    companion object {
+        fun local(uri: String): VideoSeekPreview = VideoSeekPreview(
+            pageUrls = emptyList(),
+            frameWidthPx = 0,
+            frameHeightPx = 0,
+            framesPerPageX = 0,
+            framesPerPageY = 0,
+            totalFrameCount = 0,
+            durationPerFrameMs = 0,
+            localVideoUri = uri,
+        )
     }
 }
 

--- a/app/src/main/java/com/ivor/ivormusic/ui/downloads/SongDownloadSheet.kt
+++ b/app/src/main/java/com/ivor/ivormusic/ui/downloads/SongDownloadSheet.kt
@@ -1,0 +1,177 @@
+package com.ivor.ivormusic.ui.downloads
+
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.layout.width
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.rounded.Download
+import androidx.compose.material.icons.rounded.Storage
+import androidx.compose.material3.Button
+import androidx.compose.material3.ContainedLoadingIndicator
+import androidx.compose.material3.ExperimentalMaterial3Api
+import androidx.compose.material3.Icon
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.ModalBottomSheet
+import androidx.compose.material3.Text
+import androidx.compose.material3.rememberModalBottomSheetState
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.platform.LocalContext
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.text.style.TextOverflow
+import androidx.compose.ui.unit.dp
+import com.ivor.ivormusic.data.DownloadRepository
+import com.ivor.ivormusic.data.Song
+import com.ivor.ivormusic.ui.components.SongArtwork
+import java.util.Locale
+
+/** Confirmation surface shared by every individual music download entry point. */
+@OptIn(ExperimentalMaterial3Api::class)
+@Composable
+fun SongDownloadSheet(
+    song: Song,
+    onConfirm: () -> Unit,
+    onDismiss: () -> Unit
+) {
+    val context = LocalContext.current
+    val repository = remember(context) { DownloadRepository.getInstance(context) }
+    val sheetState = rememberModalBottomSheetState(skipPartiallyExpanded = true)
+    var estimatedBytes by remember(song.id) { mutableStateOf<Long?>(null) }
+    var sizeLoading by remember(song.id) { mutableStateOf(true) }
+
+    LaunchedEffect(song.id) {
+        estimatedBytes = repository.estimateSongDownloadBytes(song)
+        sizeLoading = false
+    }
+
+    ModalBottomSheet(
+        onDismissRequest = onDismiss,
+        sheetState = sheetState,
+        containerColor = MaterialTheme.colorScheme.surfaceContainer,
+        contentColor = MaterialTheme.colorScheme.onSurface
+    ) {
+        Column(
+            modifier = Modifier
+                .fillMaxWidth()
+                .padding(horizontal = 20.dp)
+                .padding(bottom = 32.dp)
+        ) {
+            Text(
+                text = "Download song",
+                style = MaterialTheme.typography.headlineSmall
+            )
+
+            Spacer(Modifier.height(16.dp))
+
+            Row(
+                verticalAlignment = Alignment.CenterVertically,
+                horizontalArrangement = Arrangement.spacedBy(12.dp)
+            ) {
+                SongArtwork(
+                    song = song,
+                    contentDescription = null,
+                    modifier = Modifier.size(64.dp)
+                )
+                Column(modifier = Modifier.weight(1f)) {
+                    Text(
+                        text = song.title,
+                        style = MaterialTheme.typography.titleMedium,
+                        fontWeight = FontWeight.SemiBold,
+                        maxLines = 2,
+                        overflow = TextOverflow.Ellipsis
+                    )
+                    Text(
+                        text = song.artist,
+                        style = MaterialTheme.typography.bodyMedium,
+                        color = MaterialTheme.colorScheme.onSurfaceVariant,
+                        maxLines = 1,
+                        overflow = TextOverflow.Ellipsis
+                    )
+                }
+            }
+
+            Spacer(Modifier.height(20.dp))
+
+            Row(
+                modifier = Modifier.fillMaxWidth(),
+                verticalAlignment = Alignment.CenterVertically,
+                horizontalArrangement = Arrangement.spacedBy(12.dp)
+            ) {
+                Icon(
+                    imageVector = Icons.Rounded.Storage,
+                    contentDescription = null,
+                    tint = MaterialTheme.colorScheme.primary,
+                    modifier = Modifier.size(24.dp)
+                )
+                Column(modifier = Modifier.weight(1f)) {
+                    Text(
+                        text = "Estimated download",
+                        style = MaterialTheme.typography.labelLarge,
+                        color = MaterialTheme.colorScheme.onSurfaceVariant
+                    )
+                    when {
+                        sizeLoading -> ContainedLoadingIndicator(modifier = Modifier.size(24.dp))
+                        estimatedBytes != null -> Text(
+                            text = formatDownloadSize(estimatedBytes!!),
+                            style = MaterialTheme.typography.titleLarge,
+                            fontWeight = FontWeight.Bold
+                        )
+                        else -> Text(
+                            text = "Size unavailable",
+                            style = MaterialTheme.typography.titleMedium,
+                            color = MaterialTheme.colorScheme.onSurfaceVariant
+                        )
+                    }
+                }
+            }
+
+            Text(
+                text = "Artwork and lyrics may add a little to the final size.",
+                style = MaterialTheme.typography.bodySmall,
+                color = MaterialTheme.colorScheme.onSurfaceVariant,
+                modifier = Modifier.padding(top = 8.dp)
+            )
+
+            Spacer(Modifier.height(20.dp))
+
+            Button(
+                onClick = onConfirm,
+                enabled = !sizeLoading,
+                shape = RoundedCornerShape(20.dp),
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .height(56.dp)
+            ) {
+                Icon(Icons.Rounded.Download, contentDescription = null)
+                Spacer(Modifier.width(8.dp))
+                Text(
+                    text = estimatedBytes?.let { "Download • ${formatDownloadSize(it)}" }
+                        ?: "Download",
+                    fontWeight = FontWeight.SemiBold
+                )
+            }
+        }
+    }
+}
+
+internal fun formatDownloadSize(bytes: Long): String {
+    val mib = bytes / (1024.0 * 1024.0)
+    return if (mib >= 1024.0) {
+        String.format(Locale.US, "%.1f GB", mib / 1024.0)
+    } else {
+        String.format(Locale.US, "%.1f MB", mib)
+    }
+}

--- a/app/src/main/java/com/ivor/ivormusic/ui/home/HomeViewModel.kt
+++ b/app/src/main/java/com/ivor/ivormusic/ui/home/HomeViewModel.kt
@@ -28,6 +28,16 @@ import kotlinx.coroutines.flow.map
 import kotlinx.coroutines.flow.stateIn
 import kotlinx.coroutines.launch
 
+internal fun shouldWarmSubscriptionFeed(
+    source: String,
+    hasLocalSubscriptions: Boolean,
+    isLoggedIn: Boolean
+): Boolean = when (source) {
+    com.ivor.ivormusic.data.ThemePreferences.SUBSCRIPTIONS_LOCAL -> hasLocalSubscriptions
+    com.ivor.ivormusic.data.ThemePreferences.SUBSCRIPTIONS_YOUTUBE -> isLoggedIn
+    else -> hasLocalSubscriptions || isLoggedIn
+}
+
 class HomeViewModel(application: Application) : AndroidViewModel(application) {
     private val localRepository = SongRepository(application)
     private val youtubeRepository = YouTubeRepository(application)
@@ -437,6 +447,13 @@ class HomeViewModel(application: Application) : AndroidViewModel(application) {
     private val _isSubscriptionFeedLoading = MutableStateFlow(false)
     val isSubscriptionFeedLoading: StateFlow<Boolean> = _isSubscriptionFeedLoading.asStateFlow()
 
+    // A force request can arrive while a large imported list is still being
+    // fetched (for example, the import finishes during startup warm-up). The
+    // old guard dropped it outright, leaving the newly added channels absent
+    // until the user pulled manually. Coalesce those requests into one follow-
+    // up pass instead of running two hundred-channel refreshes concurrently.
+    private var subscriptionFeedRefreshPending = false
+
     private val _selectedChannelFeed = MutableStateFlow<List<VideoItem>>(emptyList())
     val selectedChannelFeed: StateFlow<List<VideoItem>> = _selectedChannelFeed.asStateFlow()
 
@@ -549,8 +566,45 @@ class HomeViewModel(application: Application) : AndroidViewModel(application) {
     val isPlaylistVideosLoading: StateFlow<Boolean> = _isPlaylistVideosLoading.asStateFlow()
 
     init {
+        observeSubscriptionFeedWarmup()
         checkYouTubeConnection()
         observeProfileSwitches()
+    }
+
+    /**
+     * Warm the Subscriptions feed from its real inputs, independently of the
+     * tab's composition. Local imports are already persisted and available at
+     * ViewModel construction, so a signed-out user now starts fetching their
+     * device feed as the app opens and sees it ready (or already progressing)
+     * when they visit Subscriptions.
+     *
+     * Only channel ids participate in the key. Avatar/profile backfill rewrites
+     * the same subscriptions and must not restart a potentially large feed.
+     */
+    private fun observeSubscriptionFeedWarmup() {
+        viewModelScope.launch {
+            combine(
+                localSubscriptions
+                    .map { subscriptions -> subscriptions.map { it.channelId }.sorted() }
+                    .distinctUntilChanged(),
+                themePreferences.subscriptionSource,
+                themePreferences.fastSubscriptionFeed
+            ) { localIds, source, fastMode -> Triple(localIds, source, fastMode) }
+                .distinctUntilChanged()
+                .collect { (localIds, source, _) ->
+                    if (shouldWarmSubscriptionFeed(
+                            source = source,
+                            hasLocalSubscriptions = localIds.isNotEmpty(),
+                            isLoggedIn = sessionManager.isLoggedIn()
+                        )
+                    ) {
+                        loadSubscriptionFeed(force = true)
+                    } else {
+                        _subscriptionFeed.value = emptyList()
+                        _subscriptionFeedError.value = null
+                    }
+                }
+        }
     }
 
     /**
@@ -677,10 +731,15 @@ class HomeViewModel(application: Application) : AndroidViewModel(application) {
     }
 
     fun loadSubscriptionFeed(force: Boolean = false) {
-        if (_isSubscriptionFeedLoading.value) return
+        if (_isSubscriptionFeedLoading.value) {
+            if (force) subscriptionFeedRefreshPending = true
+            return
+        }
         if (_subscriptionFeed.value.isNotEmpty() && !force) return
+        // Claim the refresh before launching so two callers in the same main-
+        // thread frame cannot both pass the guard and start duplicate work.
+        _isSubscriptionFeedLoading.value = true
         viewModelScope.launch {
-            _isSubscriptionFeedLoading.value = true
             _subscriptionFeedError.value = null
             try {
                 val source = themePreferences.currentSubscriptionSource()
@@ -718,6 +777,10 @@ class HomeViewModel(application: Application) : AndroidViewModel(application) {
             } finally {
                 _subscriptionFeedProgress.value = null
                 _isSubscriptionFeedLoading.value = false
+                if (subscriptionFeedRefreshPending) {
+                    subscriptionFeedRefreshPending = false
+                    loadSubscriptionFeed(force = true)
+                }
             }
         }
     }
@@ -915,7 +978,6 @@ class HomeViewModel(application: Application) : AndroidViewModel(application) {
                     )
                 )
                 backfillLocalChannelProfiles()
-                loadSubscriptionFeed(force = true)
             } catch (e: Exception) {
                 KLog.e("HomeViewModel", "Subscription import failed", e)
                 onResult(

--- a/app/src/main/java/com/ivor/ivormusic/ui/library/LibraryScreen.kt
+++ b/app/src/main/java/com/ivor/ivormusic/ui/library/LibraryScreen.kt
@@ -57,6 +57,7 @@ import androidx.compose.ui.focus.focusRequester
 import androidx.compose.ui.graphics.Brush
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.graphics.graphicsLayer
+import androidx.compose.ui.graphics.lerp
 import androidx.compose.ui.graphics.vector.ImageVector
 import androidx.compose.ui.hapticfeedback.HapticFeedbackType
 import androidx.compose.ui.input.pointer.pointerInput
@@ -501,7 +502,7 @@ fun LibraryMainScreen(
             Row(
                 modifier = Modifier.fillMaxWidth(),
                 horizontalArrangement = Arrangement.SpaceBetween,
-                verticalAlignment = Alignment.Top
+                verticalAlignment = Alignment.CenterVertically
             ) {
                 // displayLarge is 57sp and "Library" is most of the width at
                 // that size, so this row has space for exactly one action.
@@ -682,12 +683,21 @@ fun LibraryMainScreen(
         button = {
             ToggleFloatingActionButton(
                 checked = fabMenuExpanded,
-                onCheckedChange = { fabMenuExpanded = it }
+                onCheckedChange = { fabMenuExpanded = it },
+                containerColor = ToggleFloatingActionButtonDefaults.containerColor(
+                    initialColor = MaterialTheme.colorScheme.primaryContainer,
+                    finalColor = MaterialTheme.colorScheme.primary
+                )
             ) {
                 Icon(
                     Icons.Rounded.Add,
                     contentDescription = if (fabMenuExpanded) "Close menu" else "Library actions",
                     // + rotates into × as the menu blossoms open
+                    tint = lerp(
+                        MaterialTheme.colorScheme.onPrimaryContainer,
+                        MaterialTheme.colorScheme.onPrimary,
+                        checkedProgress
+                    ),
                     modifier = Modifier.graphicsLayer { rotationZ = checkedProgress * 45f }
                 )
             }
@@ -699,7 +709,9 @@ fun LibraryMainScreen(
                 showCreatePlaylistDialog = true
             },
             icon = { Icon(Icons.AutoMirrored.Rounded.PlaylistAdd, null) },
-            text = { Text("New playlist") }
+            text = { Text("New playlist") },
+            containerColor = MaterialTheme.colorScheme.secondaryContainer,
+            contentColor = MaterialTheme.colorScheme.onSecondaryContainer
         )
         FloatingActionButtonMenuItem(
             onClick = {
@@ -707,7 +719,9 @@ fun LibraryMainScreen(
                 onDownloadsClick()
             },
             icon = { Icon(Icons.Rounded.DownloadDone, null) },
-            text = { Text("Downloads") }
+            text = { Text("Downloads") },
+            containerColor = MaterialTheme.colorScheme.secondaryContainer,
+            contentColor = MaterialTheme.colorScheme.onSecondaryContainer
         )
         FloatingActionButtonMenuItem(
             onClick = {
@@ -715,7 +729,9 @@ fun LibraryMainScreen(
                 onNavigateToHistory()
             },
             icon = { Icon(Icons.Rounded.History, null) },
-            text = { Text("Listening history") }
+            text = { Text("Listening history") },
+            containerColor = MaterialTheme.colorScheme.secondaryContainer,
+            contentColor = MaterialTheme.colorScheme.onSecondaryContainer
         )
         FloatingActionButtonMenuItem(
             onClick = {
@@ -723,7 +739,9 @@ fun LibraryMainScreen(
                 onNavigateToStats()
             },
             icon = { Icon(Icons.Rounded.Insights, null) },
-            text = { Text("Statistics") }
+            text = { Text("Statistics") },
+            containerColor = MaterialTheme.colorScheme.secondaryContainer,
+            contentColor = MaterialTheme.colorScheme.onSecondaryContainer
         )
     }
 

--- a/app/src/main/java/com/ivor/ivormusic/ui/player/PlayerViewModel.kt
+++ b/app/src/main/java/com/ivor/ivormusic/ui/player/PlayerViewModel.kt
@@ -1176,15 +1176,28 @@ class PlayerViewModel(private val context: Context) : ViewModel() {
     }
     
     // --- Download Actions ---
-    
+
+    private val _pendingSongDownload = MutableStateFlow<Song?>(null)
+    val pendingSongDownload: StateFlow<Song?> = _pendingSongDownload.asStateFlow()
+
     fun toggleDownload(song: Song) {
-        viewModelScope.launch {
-            if (downloadRepository.isDownloaded(song.id)) {
+        if (downloadRepository.isDownloaded(song.id)) {
+            viewModelScope.launch {
                 downloadRepository.deleteDownload(song.id)
-            } else {
-                downloadRepository.downloadSong(song)
             }
+        } else if (!downloadRepository.isLocalOriginal(song) && !isDownloading(song.id)) {
+            _pendingSongDownload.value = song
         }
+    }
+
+    fun dismissPendingSongDownload() {
+        _pendingSongDownload.value = null
+    }
+
+    fun confirmPendingSongDownload() {
+        val song = _pendingSongDownload.value ?: return
+        _pendingSongDownload.value = null
+        viewModelScope.launch { downloadRepository.downloadSong(song) }
     }
     
     fun isDownloaded(songId: String): Boolean {

--- a/app/src/main/java/com/ivor/ivormusic/ui/video/PipVideoSurface.kt
+++ b/app/src/main/java/com/ivor/ivormusic/ui/video/PipVideoSurface.kt
@@ -37,6 +37,9 @@ fun PipVideoSurface(
 ) {
     val exoPlayer = viewModel.exoPlayer ?: return
     val captionCues by viewModel.captionCues.collectAsState()
+    val captionTextSize by viewModel.captionTextSize.collectAsState()
+    val captionTextColor by viewModel.captionTextColor.collectAsState()
+    val captionBackground by viewModel.captionBackground.collectAsState()
 
     androidx.compose.foundation.layout.Box(
         modifier = modifier
@@ -73,7 +76,10 @@ fun PipVideoSurface(
             cues = captionCues,
             player = exoPlayer,
             bottomPadding = 8.dp,
-            compact = true
+            compact = true,
+            textSize = captionTextSize,
+            textColor = captionTextColor,
+            background = captionBackground
         )
     }
 }

--- a/app/src/main/java/com/ivor/ivormusic/ui/video/SubscriptionsContent.kt
+++ b/app/src/main/java/com/ivor/ivormusic/ui/video/SubscriptionsContent.kt
@@ -287,9 +287,12 @@ fun SubscriptionsContent(
 
     // Re-runs when the account connects or the local list changes size, so
     // subscribing to a first channel while signed out fills the tab straight
-    // away instead of leaving the empty state up until a manual refresh.
+    // away instead of leaving the empty state up until a manual refresh. The
+    // ViewModel also warms this before the tab is composed; this non-forced
+    // call simply covers account connection without duplicating an in-flight
+    // local refresh.
     LaunchedEffect(isYouTubeConnected, localSubscriptions.size) {
-        viewModel.loadSubscriptionFeed(force = localSubscriptions.isNotEmpty() && feed.isEmpty())
+        viewModel.loadSubscriptionFeed()
         viewModel.loadSubscriptions()
     }
 

--- a/app/src/main/java/com/ivor/ivormusic/ui/video/VerticalLivePlayerContent.kt
+++ b/app/src/main/java/com/ivor/ivormusic/ui/video/VerticalLivePlayerContent.kt
@@ -82,7 +82,6 @@ import coil.compose.AsyncImage
 import com.ivor.ivormusic.data.LikeStatus
 import com.ivor.ivormusic.data.CaptionBackground
 import com.ivor.ivormusic.data.CaptionTextColor
-import com.ivor.ivormusic.data.CaptionTextSize
 import com.ivor.ivormusic.data.LiveChatMessage
 import com.ivor.ivormusic.data.VideoItem
 import com.ivor.ivormusic.data.VttCue
@@ -146,7 +145,7 @@ fun VerticalLivePlayerContent(
     canSendChat: Boolean,
     captionsActive: Boolean,
     captionCues: List<VttCue>,
-    captionTextSize: CaptionTextSize,
+    captionTextSize: Float,
     captionTextColor: CaptionTextColor,
     captionBackground: CaptionBackground,
     /** Null until the first frame decodes; drives the fill-vs-fit decision. */

--- a/app/src/main/java/com/ivor/ivormusic/ui/video/VerticalLivePlayerContent.kt
+++ b/app/src/main/java/com/ivor/ivormusic/ui/video/VerticalLivePlayerContent.kt
@@ -80,6 +80,9 @@ import androidx.media3.ui.AspectRatioFrameLayout
 import androidx.media3.ui.PlayerView
 import coil.compose.AsyncImage
 import com.ivor.ivormusic.data.LikeStatus
+import com.ivor.ivormusic.data.CaptionBackground
+import com.ivor.ivormusic.data.CaptionTextColor
+import com.ivor.ivormusic.data.CaptionTextSize
 import com.ivor.ivormusic.data.LiveChatMessage
 import com.ivor.ivormusic.data.VideoItem
 import com.ivor.ivormusic.data.VttCue
@@ -143,6 +146,9 @@ fun VerticalLivePlayerContent(
     canSendChat: Boolean,
     captionsActive: Boolean,
     captionCues: List<VttCue>,
+    captionTextSize: CaptionTextSize,
+    captionTextColor: CaptionTextColor,
+    captionBackground: CaptionBackground,
     /** Null until the first frame decodes; drives the fill-vs-fit decision. */
     videoAspectRatio: Float?,
     isSubscribed: Boolean,
@@ -285,7 +291,10 @@ fun VerticalLivePlayerContent(
                 cues = captionCues,
                 player = exoPlayer,
                 bottomPadding = captionBottomPadding,
-                compact = true
+                compact = true,
+                textSize = captionTextSize,
+                textColor = captionTextColor,
+                background = captionBackground
             )
 
             if (hasError) ErrorOverlay(errorMessage, onRetry)

--- a/app/src/main/java/com/ivor/ivormusic/ui/video/VideoDownloadSheet.kt
+++ b/app/src/main/java/com/ivor/ivormusic/ui/video/VideoDownloadSheet.kt
@@ -27,6 +27,7 @@ import androidx.compose.material.icons.rounded.Check
 import androidx.compose.material.icons.rounded.CheckCircle
 import androidx.compose.material.icons.rounded.Download
 import androidx.compose.material.icons.rounded.ErrorOutline
+import androidx.compose.material.icons.rounded.Storage
 import androidx.compose.material3.Button
 import androidx.compose.material3.ContainedLoadingIndicator
 import androidx.compose.material3.ExperimentalMaterial3Api
@@ -63,6 +64,7 @@ import com.ivor.ivormusic.data.ThemePreferences
 import com.ivor.ivormusic.data.VideoItem
 import com.ivor.ivormusic.data.VideoQuality
 import com.ivor.ivormusic.data.YouTubeRepository
+import com.ivor.ivormusic.ui.downloads.formatDownloadSize
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.launch
 
@@ -97,6 +99,9 @@ fun VideoDownloadSheet(
     var selectedLabel by remember(video.videoId) { mutableStateOf<String?>(null) }
     var rememberQuality by remember { mutableStateOf(false) }
     var queued by remember(video.videoId) { mutableStateOf(false) }
+    var estimatedBytes by remember(video.videoId) { mutableStateOf<Long?>(null) }
+    var sizeLoading by remember(video.videoId) { mutableStateOf(false) }
+    var sizeResolved by remember(video.videoId) { mutableStateOf(false) }
 
     val downloadedVideos by downloadRepository.downloadedVideos.collectAsState()
     val progressMap by downloadRepository.downloadProgress.collectAsState()
@@ -137,6 +142,22 @@ fun VideoDownloadSheet(
             options = emptyList()
             loadFailed = true
         }
+    }
+
+    LaunchedEffect(selectedLabel, options) {
+        val selected = options.orEmpty().firstOrNull { it.resolution == selectedLabel }
+        if (selected == null) {
+            estimatedBytes = null
+            sizeLoading = false
+            sizeResolved = false
+            return@LaunchedEffect
+        }
+        estimatedBytes = null
+        sizeResolved = false
+        sizeLoading = true
+        estimatedBytes = downloadRepository.estimateVideoDownloadBytes(selected)
+        sizeLoading = false
+        sizeResolved = true
     }
 
     // Linger on the queued state for a beat, then close (same rhythm as the
@@ -251,6 +272,44 @@ fun VideoDownloadSheet(
 
             Spacer(modifier = Modifier.height(16.dp))
 
+            if (selectedLabel != null) {
+                Row(
+                    modifier = Modifier.fillMaxWidth(),
+                    verticalAlignment = Alignment.CenterVertically,
+                    horizontalArrangement = Arrangement.spacedBy(10.dp)
+                ) {
+                    Icon(
+                        imageVector = Icons.Rounded.Storage,
+                        contentDescription = null,
+                        tint = MaterialTheme.colorScheme.primary,
+                        modifier = Modifier.size(22.dp)
+                    )
+                    Column(modifier = Modifier.weight(1f)) {
+                        Text(
+                            text = "Estimated download",
+                            style = MaterialTheme.typography.labelLarge,
+                            color = MaterialTheme.colorScheme.onSurfaceVariant
+                        )
+                        Text(
+                            text = when {
+                                sizeLoading -> "Calculating size…"
+                                estimatedBytes != null -> formatDownloadSize(estimatedBytes!!)
+                                sizeResolved -> "Size unavailable"
+                                else -> ""
+                            },
+                            style = MaterialTheme.typography.titleMedium,
+                            fontWeight = FontWeight.Bold,
+                            color = if (estimatedBytes == null && sizeResolved) {
+                                MaterialTheme.colorScheme.onSurfaceVariant
+                            } else {
+                                MaterialTheme.colorScheme.onSurface
+                            }
+                        )
+                    }
+                }
+                Spacer(modifier = Modifier.height(16.dp))
+            }
+
             // Remember-as-default switch: persisted only when the download
             // actually starts, so browsing pills never rewrites the default
             Row(
@@ -286,7 +345,8 @@ fun VideoDownloadSheet(
                     scope.launch { downloadRepository.downloadVideo(video, label) }
                     queued = true
                 },
-                enabled = selectedLabel != null && !queued && !alreadyDownloaded && !inFlight,
+                enabled = selectedLabel != null && !sizeLoading && sizeResolved &&
+                    !queued && !alreadyDownloaded && !inFlight,
                 shape = RoundedCornerShape(20.dp),
                 modifier = Modifier
                     .fillMaxWidth()
@@ -317,7 +377,12 @@ fun VideoDownloadSheet(
                             modifier = Modifier.size(22.dp)
                         )
                         Spacer(modifier = Modifier.width(8.dp))
-                        Text(text = "Download", fontWeight = FontWeight.SemiBold)
+                        Text(
+                            text = estimatedBytes?.let {
+                                "Download • ${formatDownloadSize(it)}"
+                            } ?: "Download",
+                            fontWeight = FontWeight.SemiBold
+                        )
                     }
                 }
             }

--- a/app/src/main/java/com/ivor/ivormusic/ui/video/VideoPlayerContent.kt
+++ b/app/src/main/java/com/ivor/ivormusic/ui/video/VideoPlayerContent.kt
@@ -3,7 +3,6 @@ package com.ivor.ivormusic.ui.video
 import android.app.Activity
 import android.content.pm.ActivityInfo
 import android.os.Build
-import android.view.WindowManager
 import androidx.annotation.OptIn
 import androidx.compose.animation.AnimatedVisibility
 import androidx.compose.animation.fadeIn
@@ -369,22 +368,9 @@ fun VideoPlayerContent(
         val window = activity?.window
         val insetsController = window?.let { WindowCompat.getInsetsController(it, it.decorView) }
 
-        fun setCutoutMode(mode: Int) {
-            if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.P && window != null) {
-                window.attributes = window.attributes.also { it.layoutInDisplayCutoutMode = mode }
-            }
-        }
-
         if (isFullscreen) {
             // Allow content to draw behind system bars first
             window?.let { WindowCompat.setDecorFitsSystemWindows(it, false) }
-            // Draw into the camera cutout area too, otherwise the system
-            // letterboxes the window and background shows around the notch
-            // The moving image is background content and should use every
-            // physical pixel, including waterfall/corner-cutout layouts. The
-            // controls independently apply displayCutoutPadding, so only the
-            // video and its gradients extend behind camera hardware.
-            setCutoutMode(WindowManager.LayoutParams.LAYOUT_IN_DISPLAY_CUTOUT_MODE_ALWAYS)
             // A vertical video fills the screen held upright, so fullscreen
             // holds it there rather than rotating into a letterboxed strip.
             // Everything else gets sensor landscape, both directions, like
@@ -401,13 +387,11 @@ fun VideoPlayerContent(
         } else {
             activity?.requestedOrientation = ActivityInfo.SCREEN_ORIENTATION_PORTRAIT
             insetsController?.show(WindowInsetsCompat.Type.systemBars())
-            setCutoutMode(WindowManager.LayoutParams.LAYOUT_IN_DISPLAY_CUTOUT_MODE_DEFAULT)
         }
 
         onDispose {
             activity?.requestedOrientation = ActivityInfo.SCREEN_ORIENTATION_PORTRAIT
             insetsController?.show(WindowInsetsCompat.Type.systemBars())
-            setCutoutMode(WindowManager.LayoutParams.LAYOUT_IN_DISPLAY_CUTOUT_MODE_DEFAULT)
             // The app is edge-to-edge (enableEdgeToEdge in MainActivity), so
             // keep decorFits false — restoring true here used to break the
             // edge-to-edge layout for the rest of the session
@@ -691,7 +675,6 @@ fun VideoPlayerContent(
                         modifier = Modifier
                             .fillMaxHeight()
                             .width(400.dp)
-                            .displayCutoutPadding()
                             .padding(end = 8.dp, top = 8.dp, bottom = 8.dp)
                             .clip(RoundedCornerShape(20.dp))
                     )
@@ -728,10 +711,6 @@ fun VideoPlayerContent(
                         modifier = Modifier
                             .fillMaxHeight()
                             .width(landscapeChatWidth)
-                            // Immersive fullscreen hides the system bars but
-                            // not the camera cutout, which is exactly where a
-                            // right-docked panel lands in landscape.
-                            .displayCutoutPadding()
                             .padding(end = 8.dp, top = 8.dp, bottom = 8.dp)
                             // Swallow taps: the gesture surface underneath
                             // would otherwise toggle the player controls when
@@ -1295,7 +1274,6 @@ fun VideoPlayerContent(
                 Surface(
                     modifier = Modifier
                         .fillMaxHeight()
-                        .windowInsetsPadding(WindowInsets.displayCutout.only(WindowInsetsSides.End))
                         .padding(12.dp)
                         .width(360.dp),
                     shape = RoundedCornerShape(28.dp),

--- a/app/src/main/java/com/ivor/ivormusic/ui/video/VideoPlayerContent.kt
+++ b/app/src/main/java/com/ivor/ivormusic/ui/video/VideoPlayerContent.kt
@@ -55,6 +55,7 @@ import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.platform.LocalView
 import androidx.compose.ui.semantics.Role
 import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.unit.Velocity
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.window.DialogWindowProvider
@@ -63,6 +64,9 @@ import androidx.core.view.WindowInsetsCompat
 import androidx.core.view.WindowInsetsControllerCompat
 import androidx.media3.common.util.UnstableApi
 import coil.compose.AsyncImage
+import com.ivor.ivormusic.data.CaptionBackground
+import com.ivor.ivormusic.data.CaptionTextColor
+import com.ivor.ivormusic.data.CaptionTextSize
 import com.ivor.ivormusic.data.CaptionTrack
 import com.ivor.ivormusic.data.LikeStatus
 import com.ivor.ivormusic.data.VideoChapter
@@ -125,6 +129,9 @@ fun VideoPlayerContent(
     val captionTracks by viewModel.captionTracks.collectAsState()
     val selectedCaption by viewModel.selectedCaption.collectAsState()
     val captionCues by viewModel.captionCues.collectAsState()
+    val captionTextSize by viewModel.captionTextSize.collectAsState()
+    val captionTextColor by viewModel.captionTextColor.collectAsState()
+    val captionBackground by viewModel.captionBackground.collectAsState()
     val videoAspectRatio by viewModel.videoAspectRatio.collectAsState()
 
     // PiP is a device capability, not a given: Android TV and a few OEM builds
@@ -610,6 +617,9 @@ fun VideoPlayerContent(
                     showCaptionsSheet = true
                 },
                 captionCues = captionCues,
+                captionTextSize = captionTextSize,
+                captionTextColor = captionTextColor,
+                captionBackground = captionBackground,
                 showQueueControls = queue != null,
                 hasPreviousInQueue = queue?.hasPrevious == true,
                 hasNextInQueue = queue?.hasNext == true,
@@ -775,6 +785,9 @@ fun VideoPlayerContent(
                     canSendChat = canSendLiveChat,
                     captionsActive = selectedCaption != null,
                     captionCues = captionCues,
+                    captionTextSize = captionTextSize,
+                    captionTextColor = captionTextColor,
+                    captionBackground = captionBackground,
                     videoAspectRatio = videoAspectRatio,
                     // Account OR device subscription, same as everywhere else -
                     // engagement.isSubscribed only knows about the account.
@@ -905,6 +918,9 @@ fun VideoPlayerContent(
                             showCaptionsSheet = true
                         },
                         captionCues = captionCues,
+                        captionTextSize = captionTextSize,
+                        captionTextColor = captionTextColor,
+                        captionBackground = captionBackground,
                         showQueueControls = queue != null,
                         hasPreviousInQueue = queue?.hasPrevious == true,
                         hasNextInQueue = queue?.hasNext == true,
@@ -1160,10 +1176,16 @@ fun VideoPlayerContent(
             tracks = captionTracks,
             selected = selectedCaption,
             isLoading = isCaptionsLoading,
+            textSize = captionTextSize,
+            textColor = captionTextColor,
+            background = captionBackground,
             onSelect = {
                 viewModel.setCaptionTrack(it)
                 showCaptionsSheet = false
             },
+            onTextSizeChanged = viewModel::setCaptionTextSize,
+            onTextColorChanged = viewModel::setCaptionTextColor,
+            onBackgroundChanged = viewModel::setCaptionBackground,
             onDismiss = { showCaptionsSheet = false },
             keepSystemBarsHidden = isFullscreen
         )
@@ -1724,7 +1746,13 @@ private fun CaptionsSheet(
     tracks: List<CaptionTrack>,
     selected: CaptionTrack?,
     isLoading: Boolean,
+    textSize: CaptionTextSize,
+    textColor: CaptionTextColor,
+    background: CaptionBackground,
     onSelect: (CaptionTrack?) -> Unit,
+    onTextSizeChanged: (CaptionTextSize) -> Unit,
+    onTextColorChanged: (CaptionTextColor) -> Unit,
+    onBackgroundChanged: (CaptionBackground) -> Unit,
     onDismiss: () -> Unit,
     keepSystemBarsHidden: Boolean = false
 ) {
@@ -1739,33 +1767,51 @@ private fun CaptionsSheet(
             style = MaterialTheme.typography.headlineSmall,
             modifier = Modifier.padding(start = 24.dp, end = 24.dp, bottom = 8.dp)
         )
-        when {
-            isLoading && tracks.isEmpty() -> {
-                Box(
-                    modifier = Modifier
-                        .fillMaxWidth()
-                        .padding(vertical = 32.dp),
-                    contentAlignment = Alignment.Center
-                ) {
-                    ContainedLoadingIndicator()
-                }
-            }
-            tracks.isEmpty() -> {
+        LazyColumn(
+            modifier = Modifier
+                .fillMaxWidth()
+                .heightIn(max = 560.dp),
+            contentPadding = PaddingValues(bottom = 32.dp)
+        ) {
+            item {
                 Text(
-                    text = "No captions available for this video",
-                    style = MaterialTheme.typography.bodyMedium,
+                    text = "Language",
+                    style = MaterialTheme.typography.titleSmall,
                     color = MaterialTheme.colorScheme.onSurfaceVariant,
-                    modifier = Modifier.padding(horizontal = 24.dp, vertical = 24.dp)
+                    modifier = Modifier.padding(horizontal = 24.dp, vertical = 8.dp)
                 )
             }
-            else -> {
-                Column(modifier = Modifier.padding(bottom = 32.dp)) {
-                    CaptionRow(
-                        label = "Off",
-                        checked = selected == null,
-                        onClick = { onSelect(null) }
+            when {
+                isLoading && tracks.isEmpty() -> item {
+                    Box(
+                        modifier = Modifier
+                            .fillMaxWidth()
+                            .padding(vertical = 32.dp),
+                        contentAlignment = Alignment.Center
+                    ) {
+                        ContainedLoadingIndicator()
+                    }
+                }
+                tracks.isEmpty() -> item {
+                    Text(
+                        text = "No captions available for this video",
+                        style = MaterialTheme.typography.bodyMedium,
+                        color = MaterialTheme.colorScheme.onSurfaceVariant,
+                        modifier = Modifier.padding(horizontal = 24.dp, vertical = 20.dp)
                     )
-                    tracks.forEach { track ->
+                }
+                else -> {
+                    item {
+                        CaptionRow(
+                            label = "Off",
+                            checked = selected == null,
+                            onClick = { onSelect(null) }
+                        )
+                    }
+                    itemsIndexed(
+                        items = tracks,
+                        key = { index, track -> "${track.languageCode}:${track.isAutoGenerated}:$index" }
+                    ) { _, track ->
                         val label = if (track.isAutoGenerated) "${track.name} (auto)" else track.name
                         CaptionRow(
                             label = label,
@@ -1774,6 +1820,89 @@ private fun CaptionsSheet(
                         )
                     }
                 }
+            }
+
+            item {
+                HorizontalDivider(modifier = Modifier.padding(vertical = 12.dp))
+                Text(
+                    text = "Appearance",
+                    style = MaterialTheme.typography.titleMedium,
+                    modifier = Modifier.padding(horizontal = 24.dp, vertical = 8.dp)
+                )
+            }
+            item {
+                CaptionChoiceRow(
+                    label = "Text size",
+                    options = listOf(
+                        CaptionTextSize.SMALL to "Small",
+                        CaptionTextSize.MEDIUM to "Medium",
+                        CaptionTextSize.LARGE to "Large"
+                    ),
+                    selected = textSize,
+                    onSelect = onTextSizeChanged
+                )
+            }
+            item {
+                CaptionChoiceRow(
+                    label = "Text color",
+                    options = listOf(
+                        CaptionTextColor.WHITE to "White",
+                        CaptionTextColor.YELLOW to "Yellow"
+                    ),
+                    selected = textColor,
+                    onSelect = onTextColorChanged
+                )
+            }
+            item {
+                CaptionChoiceRow(
+                    label = "Background",
+                    options = listOf(
+                        CaptionBackground.NONE to "None",
+                        CaptionBackground.TRANSLUCENT to "Soft",
+                        CaptionBackground.SOLID to "Solid"
+                    ),
+                    selected = background,
+                    onSelect = onBackgroundChanged
+                )
+            }
+        }
+    }
+}
+
+@Composable
+private fun <T> CaptionChoiceRow(
+    label: String,
+    options: List<Pair<T, String>>,
+    selected: T,
+    onSelect: (T) -> Unit
+) {
+    Column(
+        modifier = Modifier.padding(horizontal = 24.dp, vertical = 8.dp),
+        verticalArrangement = Arrangement.spacedBy(8.dp)
+    ) {
+        Text(
+            text = label,
+            style = MaterialTheme.typography.labelLarge,
+            color = MaterialTheme.colorScheme.onSurfaceVariant
+        )
+        Row(
+            modifier = Modifier.fillMaxWidth(),
+            horizontalArrangement = Arrangement.spacedBy(8.dp)
+        ) {
+            options.forEach { (value, optionLabel) ->
+                FilterChip(
+                    selected = selected == value,
+                    onClick = { onSelect(value) },
+                    label = {
+                        Text(
+                            text = optionLabel,
+                            maxLines = 1,
+                            modifier = Modifier.fillMaxWidth(),
+                            textAlign = TextAlign.Center
+                        )
+                    },
+                    modifier = Modifier.weight(1f)
+                )
             }
         }
     }

--- a/app/src/main/java/com/ivor/ivormusic/ui/video/VideoPlayerContent.kt
+++ b/app/src/main/java/com/ivor/ivormusic/ui/video/VideoPlayerContent.kt
@@ -65,7 +65,8 @@ import androidx.media3.common.util.UnstableApi
 import coil.compose.AsyncImage
 import com.ivor.ivormusic.data.CaptionBackground
 import com.ivor.ivormusic.data.CaptionTextColor
-import com.ivor.ivormusic.data.CaptionTextSize
+import com.ivor.ivormusic.data.CAPTION_TEXT_SCALE_MAX
+import com.ivor.ivormusic.data.CAPTION_TEXT_SCALE_MIN
 import com.ivor.ivormusic.data.CaptionTrack
 import com.ivor.ivormusic.data.LikeStatus
 import com.ivor.ivormusic.data.VideoChapter
@@ -73,6 +74,7 @@ import com.ivor.ivormusic.data.VideoItem
 import com.ivor.ivormusic.data.VideoQuality
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.isActive
+import kotlin.math.roundToInt
 
 /** The shape of the watch page's video box when the source shape is unknown. */
 private const val DEFAULT_VIDEO_ASPECT = 16f / 9f
@@ -1724,11 +1726,11 @@ private fun CaptionsSheet(
     tracks: List<CaptionTrack>,
     selected: CaptionTrack?,
     isLoading: Boolean,
-    textSize: CaptionTextSize,
+    textSize: Float,
     textColor: CaptionTextColor,
     background: CaptionBackground,
     onSelect: (CaptionTrack?) -> Unit,
-    onTextSizeChanged: (CaptionTextSize) -> Unit,
+    onTextSizeChanged: (Float) -> Unit,
     onTextColorChanged: (CaptionTextColor) -> Unit,
     onBackgroundChanged: (CaptionBackground) -> Unit,
     onDismiss: () -> Unit,
@@ -1809,15 +1811,9 @@ private fun CaptionsSheet(
                 )
             }
             item {
-                CaptionChoiceRow(
-                    label = "Text size",
-                    options = listOf(
-                        CaptionTextSize.SMALL to "Small",
-                        CaptionTextSize.MEDIUM to "Medium",
-                        CaptionTextSize.LARGE to "Large"
-                    ),
-                    selected = textSize,
-                    onSelect = onTextSizeChanged
+                CaptionTextSizeSlider(
+                    value = textSize,
+                    onValueCommitted = onTextSizeChanged
                 )
             }
             item {
@@ -1843,6 +1839,63 @@ private fun CaptionsSheet(
                     onSelect = onBackgroundChanged
                 )
             }
+        }
+    }
+}
+
+@Composable
+private fun CaptionTextSizeSlider(
+    value: Float,
+    onValueCommitted: (Float) -> Unit
+) {
+    var sliderValue by remember(value) { mutableFloatStateOf(value) }
+    val percent = (sliderValue * 100f).roundToInt()
+
+    Column(
+        modifier = Modifier.padding(horizontal = 24.dp, vertical = 8.dp),
+        verticalArrangement = Arrangement.spacedBy(4.dp)
+    ) {
+        Row(
+            modifier = Modifier.fillMaxWidth(),
+            horizontalArrangement = Arrangement.SpaceBetween,
+            verticalAlignment = Alignment.CenterVertically
+        ) {
+            Text(
+                text = "Text size",
+                style = MaterialTheme.typography.labelLarge,
+                color = MaterialTheme.colorScheme.onSurfaceVariant
+            )
+            Text(
+                text = "$percent%",
+                style = MaterialTheme.typography.labelLarge,
+                color = MaterialTheme.colorScheme.primary
+            )
+        }
+        Slider(
+            value = sliderValue,
+            onValueChange = { raw ->
+                sliderValue = ((raw * 4f).roundToInt() / 4f)
+                    .coerceIn(CAPTION_TEXT_SCALE_MIN, CAPTION_TEXT_SCALE_MAX)
+            },
+            onValueChangeFinished = { onValueCommitted(sliderValue) },
+            valueRange = CAPTION_TEXT_SCALE_MIN..CAPTION_TEXT_SCALE_MAX,
+            steps = 6,
+            modifier = Modifier.fillMaxWidth()
+        )
+        Row(
+            modifier = Modifier.fillMaxWidth(),
+            horizontalArrangement = Arrangement.SpaceBetween
+        ) {
+            Text(
+                text = "75%",
+                style = MaterialTheme.typography.labelSmall,
+                color = MaterialTheme.colorScheme.onSurfaceVariant
+            )
+            Text(
+                text = "250%",
+                style = MaterialTheme.typography.labelSmall,
+                color = MaterialTheme.colorScheme.onSurfaceVariant
+            )
         }
     }
 }

--- a/app/src/main/java/com/ivor/ivormusic/ui/video/VideoPlayerContent.kt
+++ b/app/src/main/java/com/ivor/ivormusic/ui/video/VideoPlayerContent.kt
@@ -962,6 +962,7 @@ fun VideoPlayerContent(
                             if (isLoggedIn) viewModel.loadVideoPlaylists()
                             saveTargetVideo = currentVideo
                         },
+                        onDownloadClick = { downloadTargetVideo = currentVideo },
                         onChannelClick = {
                             val channelId = engagement?.channelId ?: currentVideo.channelId
                             if (channelId != null) onOpenChannel(channelId)

--- a/app/src/main/java/com/ivor/ivormusic/ui/video/VideoPlayerOverlay.kt
+++ b/app/src/main/java/com/ivor/ivormusic/ui/video/VideoPlayerOverlay.kt
@@ -207,12 +207,22 @@ fun VideoPlayerOverlay(
         val fullHeightPx = with(density) { fullHeight.toPx() }
         val scope = rememberCoroutineScope()
 
-        // 0 = mini player, 1 = expanded. Progress is applied only as a render
-        // transform. The old shared-element-style morph animated height,
-        // padding, shape and elevation on every frame, forcing the Android
-        // video surface through a full measure/layout pass and producing
-        // visible jank on mid-range devices.
-        val expandProgress = remember { Animatable(if (isExpanded) 1f else 0f) }
+        // 0 = mini player, 1 = expanded. Always begin at the collapsed end so
+        // opening a brand-new video gets the same reveal as tapping an existing
+        // mini player. Initialising this from isExpanded skipped every entrance
+        // frame when a video was first opened. Progress never changes layout:
+        // the Android video surface is swapped once, then cheap layers animate.
+        val expandProgress = remember { Animatable(0f) }
+
+        // A restored collapsed player also deserves an entrance instead of
+        // appearing abruptly on the first composed frame. This is read only by
+        // the mini bar's graphics layer, keeping its AndroidView out of measure
+        // and composition during the animation.
+        val miniEntrance = remember { Animatable(0f) }
+        val miniEntranceSpec = MaterialTheme.motionScheme.fastSpatialSpec<Float>()
+        LaunchedEffect(Unit) {
+            miniEntrance.animateTo(1f, miniEntranceSpec)
+        }
 
         // Live value while a finger is down. The drag deliberately does not go
         // through the Animatable: Animatable.snapTo runs under a MutatorMutex,
@@ -320,6 +330,7 @@ fun VideoPlayerOverlay(
         // a different animation entirely, so letting the bar follow the finger
         // up the screen would promise a movement that never continues.
         val miniLiftLimitPx = with(density) { 24.dp.toPx() }
+        val miniEnterOffsetPx = with(density) { 12.dp.toPx() }
         val miniOffsetAnimationSpec = MaterialTheme.motionScheme.fastSpatialSpec<Float>()
 
         // Minimized resting position clears the system navigation inset plus
@@ -342,8 +353,14 @@ fun VideoPlayerOverlay(
                 // emulator compositor and some lower-end device GPUs.
                 val progress = expandProgress.value
                 val gestureOffset = if (isMiniDragging) miniDragY else miniSettleOffset.value
-                translationY = gestureOffset
-                alpha = (1f - progress).coerceIn(0f, 1f)
+                val visibility = (
+                    (1f - progress).coerceIn(0f, 1f) * miniEntrance.value
+                ).coerceIn(0f, 1f)
+                // The collapsed bar rises a very short distance as it becomes
+                // legible. Translation and opacity are compositor-only; the
+                // embedded TextureView remains at its final 88dp size.
+                translationY = gestureOffset + (1f - visibility) * miniEnterOffsetPx
+                alpha = visibility
 
                 val fadeLimit = if (isDismissingMini) 1f else 0.5f
                 alpha *= 1f - (
@@ -573,17 +590,22 @@ fun VideoPlayerOverlay(
         }
         if (isExpanded) {
             // Reveal curtain: the full player itself is completely static.
-            // Only this cheap color layer fades away, avoiding transforms,
-            // offscreen buffers and repeated composition of live video.
+            // A plain color layer lifts toward the top while fading, revealing
+            // the destination from the mini player's bottom edge. This gives a
+            // clear spatial hand-off without scaling, translating or repeatedly
+            // laying out the live video surface.
             Box(
                 modifier = Modifier
                     .matchParentSize()
                     .graphicsLayer {
                         val progress = if (isDragging) dragProgress else expandProgress.value
-                        alpha = if (isDragging) {
-                            (1f - progress) * 0.16f
+                        if (isDragging) {
+                            translationY = 0f
+                            alpha = (1f - progress) * 0.16f
                         } else {
-                            1f - progress
+                            val reveal = progress.coerceIn(0f, 1f)
+                            translationY = -fullHeightPx * reveal
+                            alpha = 1f - reveal
                         }
                     }
                     .background(MaterialTheme.colorScheme.surfaceContainerHigh)

--- a/app/src/main/java/com/ivor/ivormusic/ui/video/VideoPlayerScreen.kt
+++ b/app/src/main/java/com/ivor/ivormusic/ui/video/VideoPlayerScreen.kt
@@ -2048,6 +2048,7 @@ fun VideoInfoSection(
     onSubscribeClick: () -> Unit = {},
     onCommentsClick: () -> Unit = {},
     onSaveClick: () -> Unit = {},
+    onDownloadClick: () -> Unit = {},
     onChannelClick: () -> Unit = {},
     onRelatedLongPress: ((VideoItem) -> Unit)? = null,
     /**
@@ -2135,7 +2136,7 @@ fun VideoInfoSection(
             )
             SaveVideoButton(onClick = onSaveClick)
             ShareVideoButton(video = video)
-            DownloadVideoButton(video = video)
+            DownloadVideoButton(video = video, onDownloadClick = onDownloadClick)
         }
 
         // Channel Info Surface (tap navigates to the channel)
@@ -2584,19 +2585,19 @@ private fun SaveVideoButton(onClick: () -> Unit) {
 }
 
 /**
- * Download pill. Queues the video into the shared download repository, which
- * fetches the best MP4 video and audio streams and remuxes them into
- * Downloads/Koda/Video. Reflects queued/downloading/downloaded state so the
- * pill is not a fire-and-forget button.
+ * Download pill. A new download opens the quality-and-size sheet; an active or
+ * completed one retains its cancel/delete behavior. This keeps the convenient
+ * status control without bypassing the user's quality choice.
  */
 @Composable
-private fun DownloadVideoButton(video: VideoItem) {
+private fun DownloadVideoButton(
+    video: VideoItem,
+    onDownloadClick: () -> Unit,
+) {
     val context = LocalContext.current
     val repository = remember(context) {
         com.ivor.ivormusic.data.DownloadRepository.getInstance(context)
     }
-    val scope = rememberCoroutineScope()
-
     val downloadedVideos by repository.downloadedVideos.collectAsState()
     val progressMap by repository.downloadProgress.collectAsState()
 
@@ -2613,7 +2614,7 @@ private fun DownloadVideoButton(video: VideoItem) {
             when {
                 downloaded -> repository.deleteVideoDownload(video.videoId)
                 inFlight -> repository.cancelDownload(video.videoId)
-                else -> scope.launch { repository.downloadVideo(video) }
+                else -> onDownloadClick()
             }
         }
     ) {

--- a/app/src/main/java/com/ivor/ivormusic/ui/video/VideoPlayerScreen.kt
+++ b/app/src/main/java/com/ivor/ivormusic/ui/video/VideoPlayerScreen.kt
@@ -157,7 +157,7 @@ import kotlin.math.roundToInt
 import com.ivor.ivormusic.data.LikeStatus
 import com.ivor.ivormusic.data.CaptionBackground
 import com.ivor.ivormusic.data.CaptionTextColor
-import com.ivor.ivormusic.data.CaptionTextSize
+import com.ivor.ivormusic.data.CAPTION_TEXT_SCALE_DEFAULT
 import com.ivor.ivormusic.data.ThemePreferences
 import com.ivor.ivormusic.data.VideoChapter
 import com.ivor.ivormusic.data.VideoEngagement
@@ -202,7 +202,7 @@ internal fun CaptionOverlay(
     player: ExoPlayer,
     bottomPadding: Dp,
     compact: Boolean,
-    textSize: CaptionTextSize,
+    textSize: Float,
     textColor: CaptionTextColor,
     background: CaptionBackground,
     modifier: Modifier = Modifier
@@ -235,11 +235,6 @@ internal fun CaptionOverlay(
                 } else {
                     MaterialTheme.typography.titleMedium
                 }
-                val sizeMultiplier = when (textSize) {
-                    CaptionTextSize.SMALL -> 0.85f
-                    CaptionTextSize.MEDIUM -> 1f
-                    CaptionTextSize.LARGE -> 1.25f
-                }
                 val foreground = when (textColor) {
                     CaptionTextColor.WHITE -> Color.White
                     CaptionTextColor.YELLOW -> Color.Yellow
@@ -257,8 +252,8 @@ internal fun CaptionOverlay(
                         text = cue,
                         color = foreground,
                         style = baseStyle.copy(
-                            fontSize = baseStyle.fontSize * sizeMultiplier,
-                            lineHeight = baseStyle.lineHeight * sizeMultiplier,
+                            fontSize = baseStyle.fontSize * textSize,
+                            lineHeight = baseStyle.lineHeight * textSize,
                             shadow = if (background == CaptionBackground.NONE) {
                                 androidx.compose.ui.graphics.Shadow(
                                     color = Color.Black,
@@ -315,7 +310,7 @@ fun FullscreenPlayerContent(
     captionsActive: Boolean = false,
     onCaptionsClick: () -> Unit = {},
     captionCues: List<VttCue> = emptyList(),
-    captionTextSize: CaptionTextSize = CaptionTextSize.MEDIUM,
+    captionTextSize: Float = CAPTION_TEXT_SCALE_DEFAULT,
     captionTextColor: CaptionTextColor = CaptionTextColor.WHITE,
     captionBackground: CaptionBackground = CaptionBackground.TRANSLUCENT,
     /**
@@ -701,7 +696,7 @@ fun PortraitPlayerContent(
     captionsActive: Boolean = false,
     onCaptionsClick: () -> Unit = {},
     captionCues: List<VttCue> = emptyList(),
-    captionTextSize: CaptionTextSize = CaptionTextSize.MEDIUM,
+    captionTextSize: Float = CAPTION_TEXT_SCALE_DEFAULT,
     captionTextColor: CaptionTextColor = CaptionTextColor.WHITE,
     captionBackground: CaptionBackground = CaptionBackground.TRANSLUCENT,
     isLive: Boolean = false,

--- a/app/src/main/java/com/ivor/ivormusic/ui/video/VideoPlayerScreen.kt
+++ b/app/src/main/java/com/ivor/ivormusic/ui/video/VideoPlayerScreen.kt
@@ -3,7 +3,10 @@ package com.ivor.ivormusic.ui.video
 import android.app.Activity
 import android.content.Context
 import android.content.Intent
+import android.graphics.Bitmap
 import android.media.AudioManager
+import android.media.MediaMetadataRetriever
+import android.net.Uri
 import android.view.ViewGroup
 import android.view.WindowManager
 import android.widget.FrameLayout
@@ -16,6 +19,7 @@ import androidx.compose.animation.core.tween
 import androidx.compose.animation.fadeIn
 import androidx.compose.animation.fadeOut
 import androidx.compose.foundation.Canvas
+import androidx.compose.foundation.Image
 import androidx.compose.foundation.background
 import androidx.compose.foundation.clickable
 import androidx.compose.foundation.combinedClickable
@@ -131,6 +135,7 @@ import androidx.compose.ui.platform.LocalHapticFeedback
 import androidx.compose.ui.graphics.Brush
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.graphics.StrokeCap
+import androidx.compose.ui.graphics.asImageBitmap
 import androidx.compose.ui.graphics.vector.ImageVector
 import androidx.compose.ui.layout.ContentScale
 import androidx.compose.ui.text.font.FontWeight
@@ -147,6 +152,7 @@ import coil.compose.AsyncImage
 import coil.request.CachePolicy
 import coil.request.ImageRequest
 import kotlin.math.abs
+import kotlin.math.min
 import kotlin.math.roundToInt
 import com.ivor.ivormusic.data.LikeStatus
 import com.ivor.ivormusic.data.CaptionBackground
@@ -160,8 +166,12 @@ import com.ivor.ivormusic.data.VideoSeekPreview
 import com.ivor.ivormusic.data.VttCue
 import com.ivor.ivormusic.data.WebVttParser
 import kotlinx.coroutines.delay
+import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.isActive
 import kotlinx.coroutines.launch
+import kotlinx.coroutines.sync.Mutex
+import kotlinx.coroutines.sync.withLock
+import kotlinx.coroutines.withContext
 import java.util.Locale
 
 // VideoPlayerScreen function removed.
@@ -1169,6 +1179,7 @@ private fun SeekPreviewCard(
     modifier: Modifier = Modifier,
 ) {
     val frame = preview?.frameAt(positionMs)
+    val localVideoUri = preview?.localVideoUri
     val context = LocalContext.current
     Surface(
         modifier = modifier,
@@ -1178,7 +1189,12 @@ private fun SeekPreviewCard(
         shadowElevation = 4.dp,
     ) {
         Column(horizontalAlignment = Alignment.CenterHorizontally) {
-            if (preview != null && frame != null) {
+            if (localVideoUri != null) {
+                LocalVideoSeekFrame(
+                    uriString = localVideoUri,
+                    positionMs = positionMs,
+                )
+            } else if (preview != null && frame != null) {
                 val frameWidth = 144.dp
                 val frameHeight = frameWidth *
                     (preview.frameHeightPx.toFloat() / preview.frameWidthPx.toFloat())
@@ -1243,6 +1259,127 @@ private fun SeekPreviewCard(
         }
     }
 }
+
+/**
+ * Decode downloaded-video previews locally, one request at a time.
+ *
+ * Positions are bucketed and briefly debounced because a slider can emit
+ * hundreds of values in one drag. The mutex prevents cancelled native decoder
+ * calls from piling up; the last good frame remains visible while the next one
+ * is extracted. Frames are deliberately small and recycled when replaced.
+ */
+@Composable
+private fun LocalVideoSeekFrame(
+    uriString: String,
+    positionMs: Long,
+) {
+    val context = LocalContext.current
+    val extractionMutex = remember(uriString) { Mutex() }
+    val frameTimeMs = (positionMs.coerceAtLeast(0L) / LOCAL_PREVIEW_BUCKET_MS) *
+        LOCAL_PREVIEW_BUCKET_MS
+    var bitmap by remember(uriString) { mutableStateOf<Bitmap?>(null) }
+
+    LaunchedEffect(uriString, frameTimeMs) {
+        delay(LOCAL_PREVIEW_DEBOUNCE_MS)
+        val next = extractionMutex.withLock {
+            extractLocalVideoFrame(context, uriString, frameTimeMs)
+        }
+        if (next != null) bitmap = next
+    }
+
+    val displayedBitmap = bitmap
+    DisposableEffect(displayedBitmap) {
+        onDispose { displayedBitmap?.recycle() }
+    }
+
+    Box(
+        modifier = Modifier
+            .size(LOCAL_PREVIEW_WIDTH, LOCAL_PREVIEW_HEIGHT)
+            .background(Color.Black),
+        contentAlignment = Alignment.Center,
+    ) {
+        if (displayedBitmap != null) {
+            Image(
+                bitmap = displayedBitmap.asImageBitmap(),
+                contentDescription = null,
+                contentScale = ContentScale.Fit,
+                modifier = Modifier.fillMaxSize(),
+            )
+        } else {
+            ContainedLoadingIndicator(modifier = Modifier.size(28.dp))
+        }
+    }
+}
+
+private suspend fun extractLocalVideoFrame(
+    context: Context,
+    uriString: String,
+    positionMs: Long,
+): Bitmap? = withContext(Dispatchers.IO) {
+    val retriever = MediaMetadataRetriever()
+    try {
+        val uri = Uri.parse(uriString)
+        if (uri.scheme.equals("file", ignoreCase = true)) {
+            val path = uri.path ?: return@withContext null
+            retriever.setDataSource(path)
+        } else {
+            retriever.setDataSource(context, uri)
+        }
+        val encodedWidth = retriever
+            .extractMetadata(MediaMetadataRetriever.METADATA_KEY_VIDEO_WIDTH)
+            ?.toIntOrNull()
+            ?: LOCAL_PREVIEW_WIDTH_PX
+        val encodedHeight = retriever
+            .extractMetadata(MediaMetadataRetriever.METADATA_KEY_VIDEO_HEIGHT)
+            ?.toIntOrNull()
+            ?: LOCAL_PREVIEW_HEIGHT_PX
+        val rotation = retriever
+            .extractMetadata(MediaMetadataRetriever.METADATA_KEY_VIDEO_ROTATION)
+            ?.toIntOrNull()
+            ?: 0
+        val (targetWidth, targetHeight) = localPreviewPixelSize(
+            encodedWidth = encodedWidth,
+            encodedHeight = encodedHeight,
+            rotationDegrees = rotation,
+        )
+        retriever.getScaledFrameAtTime(
+            positionMs * 1_000L,
+            MediaMetadataRetriever.OPTION_CLOSEST_SYNC,
+            targetWidth,
+            targetHeight,
+        )
+    } catch (_: Exception) {
+        null
+    } finally {
+        retriever.close()
+    }
+}
+
+private fun localPreviewPixelSize(
+    encodedWidth: Int,
+    encodedHeight: Int,
+    rotationDegrees: Int,
+): Pair<Int, Int> {
+    if (encodedWidth <= 0 || encodedHeight <= 0) {
+        return LOCAL_PREVIEW_WIDTH_PX to LOCAL_PREVIEW_HEIGHT_PX
+    }
+    val quarterTurn = rotationDegrees.mod(180) != 0
+    val displayWidth = if (quarterTurn) encodedHeight else encodedWidth
+    val displayHeight = if (quarterTurn) encodedWidth else encodedHeight
+    val scale = min(
+        LOCAL_PREVIEW_WIDTH_PX.toFloat() / displayWidth.toFloat(),
+        LOCAL_PREVIEW_HEIGHT_PX.toFloat() / displayHeight.toFloat(),
+    )
+    return (displayWidth * scale).roundToInt().coerceAtLeast(1) to
+        (displayHeight * scale).roundToInt().coerceAtLeast(1)
+}
+
+private const val LOCAL_PREVIEW_BUCKET_MS = 1_000L
+private const val LOCAL_PREVIEW_DEBOUNCE_MS = 60L
+private const val LOCAL_PREVIEW_WIDTH_PX = 288
+private const val LOCAL_PREVIEW_HEIGHT_PX = 162
+private val LOCAL_PREVIEW_WIDTH = 144.dp
+private val LOCAL_PREVIEW_HEIGHT = 81.dp
 
 /**
  * Pill above the seek bar showing the current chapter title; tapping it opens

--- a/app/src/main/java/com/ivor/ivormusic/ui/video/VideoPlayerScreen.kt
+++ b/app/src/main/java/com/ivor/ivormusic/ui/video/VideoPlayerScreen.kt
@@ -49,7 +49,6 @@ import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.layout.wrapContentSize
 import androidx.compose.foundation.layout.width
 import androidx.compose.foundation.layout.statusBarsPadding
-import androidx.compose.foundation.layout.displayCutoutPadding
 import androidx.compose.foundation.rememberScrollState
 import androidx.compose.foundation.shape.CircleShape
 import androidx.compose.foundation.shape.RoundedCornerShape
@@ -489,11 +488,6 @@ fun FullscreenPlayerContent(
                         .align(Alignment.TopCenter)
                         .fillMaxWidth()
                         .background(Brush.verticalGradient(colors = listOf(Color.Black.copy(0.7f), Color.Transparent)))
-                        // Cutout insets are stable, unlike status-bar insets which go
-                        // 0 -> bar-height whenever another window (a bottom sheet)
-                        // makes the hidden system bars reappear — statusBarsPadding
-                        // here made the whole top bar jump down when a sheet opened
-                        .displayCutoutPadding()
                         .padding(
                             horizontal = if (compactChrome) 16.dp else 24.dp,
                             vertical = 12.dp
@@ -605,7 +599,6 @@ fun FullscreenPlayerContent(
                                 listOf(Color.Transparent, Color.Black.copy(alpha = 0.72f))
                             )
                         )
-                        .displayCutoutPadding()
                         .padding(horizontal = 24.dp, vertical = 18.dp),
                     verticalArrangement = Arrangement.spacedBy(8.dp)
                 ) {

--- a/app/src/main/java/com/ivor/ivormusic/ui/video/VideoPlayerScreen.kt
+++ b/app/src/main/java/com/ivor/ivormusic/ui/video/VideoPlayerScreen.kt
@@ -150,6 +150,9 @@ import coil.request.ImageRequest
 import kotlin.math.abs
 import kotlin.math.roundToInt
 import com.ivor.ivormusic.data.LikeStatus
+import com.ivor.ivormusic.data.CaptionBackground
+import com.ivor.ivormusic.data.CaptionTextColor
+import com.ivor.ivormusic.data.CaptionTextSize
 import com.ivor.ivormusic.data.ThemePreferences
 import com.ivor.ivormusic.data.VideoChapter
 import com.ivor.ivormusic.data.VideoEngagement
@@ -179,9 +182,10 @@ import java.util.Locale
  * RESIZE_MODE_ZOOM, and their distance from the bottom edge is a plain padding
  * value instead of a fight with per-cue positioning.
  *
- * Black-on-white here rather than ColorScheme: captions sit on video frames, so
- * they have to stay legible whatever the app theme is. Same reasoning as the
- * player controls above them.
+ * Caption colors are intentionally video-safe rather than ColorScheme roles:
+ * they sit directly on arbitrary frames. The user's size, foreground and plate
+ * choices apply consistently in the watch page, fullscreen, vertical live and
+ * PiP, while this layout continues to own collision-free positioning.
  */
 @Composable
 internal fun CaptionOverlay(
@@ -189,6 +193,9 @@ internal fun CaptionOverlay(
     player: ExoPlayer,
     bottomPadding: Dp,
     compact: Boolean,
+    textSize: CaptionTextSize,
+    textColor: CaptionTextColor,
+    background: CaptionBackground,
     modifier: Modifier = Modifier
 ) {
     if (cues.isEmpty()) return
@@ -214,23 +221,50 @@ internal fun CaptionOverlay(
             modifier = Modifier.padding(horizontal = 16.dp)
         ) { cue ->
             if (cue != null) {
+                val baseStyle = if (compact) {
+                    MaterialTheme.typography.bodyMedium
+                } else {
+                    MaterialTheme.typography.titleMedium
+                }
+                val sizeMultiplier = when (textSize) {
+                    CaptionTextSize.SMALL -> 0.85f
+                    CaptionTextSize.MEDIUM -> 1f
+                    CaptionTextSize.LARGE -> 1.25f
+                }
+                val foreground = when (textColor) {
+                    CaptionTextColor.WHITE -> Color.White
+                    CaptionTextColor.YELLOW -> Color.Yellow
+                }
+                val plateAlpha = when (background) {
+                    CaptionBackground.NONE -> 0f
+                    CaptionBackground.TRANSLUCENT -> 0.75f
+                    CaptionBackground.SOLID -> 0.95f
+                }
                 Box(
                     modifier = Modifier.padding(bottom = bottomPadding),
                     contentAlignment = Alignment.BottomCenter
                 ) {
                     Text(
                         text = cue,
-                        color = Color.White,
-                        style = if (compact) {
-                            MaterialTheme.typography.bodyMedium
-                        } else {
-                            MaterialTheme.typography.titleMedium
-                        },
+                        color = foreground,
+                        style = baseStyle.copy(
+                            fontSize = baseStyle.fontSize * sizeMultiplier,
+                            lineHeight = baseStyle.lineHeight * sizeMultiplier,
+                            shadow = if (background == CaptionBackground.NONE) {
+                                androidx.compose.ui.graphics.Shadow(
+                                    color = Color.Black,
+                                    offset = Offset(1f, 1f),
+                                    blurRadius = 4f
+                                )
+                            } else {
+                                null
+                            }
+                        ),
                         fontWeight = FontWeight.Medium,
                         textAlign = TextAlign.Center,
                         modifier = Modifier
                             .background(
-                                color = Color.Black.copy(alpha = 0.75f),
+                                color = Color.Black.copy(alpha = plateAlpha),
                                 shape = RoundedCornerShape(8.dp)
                             )
                             .padding(horizontal = 12.dp, vertical = 6.dp)
@@ -272,6 +306,9 @@ fun FullscreenPlayerContent(
     captionsActive: Boolean = false,
     onCaptionsClick: () -> Unit = {},
     captionCues: List<VttCue> = emptyList(),
+    captionTextSize: CaptionTextSize = CaptionTextSize.MEDIUM,
+    captionTextColor: CaptionTextColor = CaptionTextColor.WHITE,
+    captionBackground: CaptionBackground = CaptionBackground.TRANSLUCENT,
     /**
      * Playlist transport and the way into the queue. Fullscreen is where a
      * playlist is most likely to be watched end to end, and leaving fullscreen
@@ -419,7 +456,10 @@ fun FullscreenPlayerContent(
             cues = captionCues,
             player = exoPlayer,
             bottomPadding = captionLift.value,
-            compact = false
+            compact = false,
+            textSize = captionTextSize,
+            textColor = captionTextColor,
+            background = captionBackground
         )
 
         // Overlays
@@ -658,6 +698,9 @@ fun PortraitPlayerContent(
     captionsActive: Boolean = false,
     onCaptionsClick: () -> Unit = {},
     captionCues: List<VttCue> = emptyList(),
+    captionTextSize: CaptionTextSize = CaptionTextSize.MEDIUM,
+    captionTextColor: CaptionTextColor = CaptionTextColor.WHITE,
+    captionBackground: CaptionBackground = CaptionBackground.TRANSLUCENT,
     isLive: Boolean = false,
     /** Jump to the live edge of the DVR window. */
     onSeekToLive: () -> Unit = {},
@@ -737,7 +780,10 @@ fun PortraitPlayerContent(
             cues = captionCues,
             player = exoPlayer,
             bottomPadding = captionLift.value,
-            compact = true
+            compact = true,
+            textSize = captionTextSize,
+            textColor = captionTextColor,
+            background = captionBackground
         )
 
         if (hasError) ErrorOverlay(errorMessage, onRetry)

--- a/app/src/main/java/com/ivor/ivormusic/ui/video/VideoPlayerViewModel.kt
+++ b/app/src/main/java/com/ivor/ivormusic/ui/video/VideoPlayerViewModel.kt
@@ -247,8 +247,9 @@ class VideoPlayerViewModel(application: android.app.Application) : AndroidViewMo
     private val _chapters = MutableStateFlow<List<com.ivor.ivormusic.data.VideoChapter>>(emptyList())
     val chapters: StateFlow<List<com.ivor.ivormusic.data.VideoChapter>> = _chapters.asStateFlow()
 
-    // YouTube storyboard sprite harvested during the stream extraction. Null
-    // for live streams, local downloads and videos that do not expose frames.
+    // YouTube storyboard sprite harvested during stream extraction, or a local
+    // URI whose frames can be decoded directly for downloaded playback. Null
+    // for live streams and videos that do not expose either source.
     private val _seekPreview = MutableStateFlow<VideoSeekPreview?>(null)
     val seekPreview: StateFlow<VideoSeekPreview?> = _seekPreview.asStateFlow()
 
@@ -1478,6 +1479,7 @@ class VideoPlayerViewModel(application: android.app.Application) : AndroidViewMo
                 )
                 _availableQualities.value = listOf(offlineQuality)
                 _currentQuality.value = offlineQuality
+                _seekPreview.value = VideoSeekPreview.local(localDownload.uri.toString())
                 _exoPlayer?.setMediaItem(nowPlayingMediaItem(localDownload.uri.toString()))
                 _exoPlayer?.prepare()
                 if (resumePositionMs != null) {

--- a/app/src/main/java/com/ivor/ivormusic/ui/video/VideoPlayerViewModel.kt
+++ b/app/src/main/java/com/ivor/ivormusic/ui/video/VideoPlayerViewModel.kt
@@ -21,6 +21,9 @@ import androidx.media3.exoplayer.ExoPlayer
 import androidx.media3.exoplayer.source.DefaultMediaSourceFactory
 import androidx.media3.exoplayer.source.MergingMediaSource
 import androidx.media3.exoplayer.source.ProgressiveMediaSource
+import com.ivor.ivormusic.data.CaptionBackground
+import com.ivor.ivormusic.data.CaptionTextColor
+import com.ivor.ivormusic.data.CaptionTextSize
 import com.ivor.ivormusic.data.CaptionTrack
 import com.ivor.ivormusic.data.CommentItem
 import com.ivor.ivormusic.data.DownloadedVideo
@@ -267,7 +270,18 @@ class VideoPlayerViewModel(application: android.app.Application) : AndroidViewMo
     private val _captionCues = MutableStateFlow<List<VttCue>>(emptyList())
     val captionCues: StateFlow<List<VttCue>> = _captionCues.asStateFlow()
 
+    val captionTextSize: StateFlow<CaptionTextSize> = themePreferences.captionTextSize
+    val captionTextColor: StateFlow<CaptionTextColor> = themePreferences.captionTextColor
+    val captionBackground: StateFlow<CaptionBackground> = themePreferences.captionBackground
+
     private var captionCuesJob: Job? = null
+
+    fun setCaptionTextSize(size: CaptionTextSize) = themePreferences.setCaptionTextSize(size)
+
+    fun setCaptionTextColor(color: CaptionTextColor) = themePreferences.setCaptionTextColor(color)
+
+    fun setCaptionBackground(background: CaptionBackground) =
+        themePreferences.setCaptionBackground(background)
 
     // ---------------- Picture-in-Picture ----------------
 

--- a/app/src/main/java/com/ivor/ivormusic/ui/video/VideoPlayerViewModel.kt
+++ b/app/src/main/java/com/ivor/ivormusic/ui/video/VideoPlayerViewModel.kt
@@ -23,7 +23,6 @@ import androidx.media3.exoplayer.source.MergingMediaSource
 import androidx.media3.exoplayer.source.ProgressiveMediaSource
 import com.ivor.ivormusic.data.CaptionBackground
 import com.ivor.ivormusic.data.CaptionTextColor
-import com.ivor.ivormusic.data.CaptionTextSize
 import com.ivor.ivormusic.data.CaptionTrack
 import com.ivor.ivormusic.data.CommentItem
 import com.ivor.ivormusic.data.DownloadedVideo
@@ -271,13 +270,13 @@ class VideoPlayerViewModel(application: android.app.Application) : AndroidViewMo
     private val _captionCues = MutableStateFlow<List<VttCue>>(emptyList())
     val captionCues: StateFlow<List<VttCue>> = _captionCues.asStateFlow()
 
-    val captionTextSize: StateFlow<CaptionTextSize> = themePreferences.captionTextSize
+    val captionTextSize: StateFlow<Float> = themePreferences.captionTextSize
     val captionTextColor: StateFlow<CaptionTextColor> = themePreferences.captionTextColor
     val captionBackground: StateFlow<CaptionBackground> = themePreferences.captionBackground
 
     private var captionCuesJob: Job? = null
 
-    fun setCaptionTextSize(size: CaptionTextSize) = themePreferences.setCaptionTextSize(size)
+    fun setCaptionTextSize(size: Float) = themePreferences.setCaptionTextSize(size)
 
     fun setCaptionTextColor(color: CaptionTextColor) = themePreferences.setCaptionTextColor(color)
 

--- a/app/src/test/java/com/ivor/ivormusic/data/CaptionTextScaleTest.kt
+++ b/app/src/test/java/com/ivor/ivormusic/data/CaptionTextScaleTest.kt
@@ -1,0 +1,21 @@
+package com.ivor.ivormusic.data
+
+import org.junit.Assert.assertEquals
+import org.junit.Test
+
+class CaptionTextScaleTest {
+
+    @Test
+    fun legacyPresetsMigrateToEquivalentSliderValues() {
+        assertEquals(0.75f, captionTextScaleFromStored("SMALL"))
+        assertEquals(1f, captionTextScaleFromStored("MEDIUM"))
+        assertEquals(1.25f, captionTextScaleFromStored("LARGE"))
+    }
+
+    @Test
+    fun persistedSliderValueIsClampedToSupportedRange() {
+        assertEquals(CAPTION_TEXT_SCALE_MIN, captionTextScaleFromStored(0.1f))
+        assertEquals(1.75f, captionTextScaleFromStored(1.75f))
+        assertEquals(CAPTION_TEXT_SCALE_MAX, captionTextScaleFromStored(9f))
+    }
+}

--- a/app/src/test/java/com/ivor/ivormusic/data/DownloadedAudioMetadataTest.kt
+++ b/app/src/test/java/com/ivor/ivormusic/data/DownloadedAudioMetadataTest.kt
@@ -1,10 +1,50 @@
 package com.ivor.ivormusic.data
 
 import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
 import org.junit.Assert.assertNotNull
+import org.junit.Assert.assertTrue
+import org.junit.Rule
 import org.junit.Test
+import org.junit.rules.TemporaryFolder
 
 class DownloadedAudioMetadataTest {
+
+    @get:Rule
+    val temporaryFolder = TemporaryFolder()
+
+    @Test
+    fun failedMetadataWritePreservesOriginalAndRemovesRejectedCopy() {
+        val source = temporaryFolder.newFile("source.m4a").apply {
+            writeBytes(byteArrayOf(1, 2, 3, 4))
+        }
+
+        val result = createMetadataCopy(source, temporaryFolder.root) { copy ->
+            copy.writeBytes(byteArrayOf(9, 9))
+            error("MP4 offsets rejected")
+        }
+
+        assertTrue(result.isFailure)
+        assertTrue(source.readBytes().contentEquals(byteArrayOf(1, 2, 3, 4)))
+        assertFalse(
+            temporaryFolder.root.listFiles().orEmpty().any { it.name.startsWith("koda_tagged_") }
+        )
+    }
+
+    @Test
+    fun successfulMetadataWriteReturnsCopyAndPreservesOriginal() {
+        val source = temporaryFolder.newFile("source.m4a").apply {
+            writeBytes(byteArrayOf(1, 2, 3, 4))
+        }
+
+        val result = createMetadataCopy(source, temporaryFolder.root) { copy ->
+            copy.appendBytes(byteArrayOf(5, 6))
+        }
+
+        assertTrue(result.isSuccess)
+        assertTrue(source.readBytes().contentEquals(byteArrayOf(1, 2, 3, 4)))
+        assertTrue(result.getOrThrow().readBytes().contentEquals(byteArrayOf(1, 2, 3, 4, 5, 6)))
+    }
 
     @Test
     fun plainLyricsRemainPlainAndCollapseEmbeddedNewlines() {

--- a/app/src/test/java/com/ivor/ivormusic/data/VideoSeekPreviewTest.kt
+++ b/app/src/test/java/com/ivor/ivormusic/data/VideoSeekPreviewTest.kt
@@ -73,6 +73,16 @@ class VideoSeekPreviewTest {
         assertNull(preview(durationPerFrameMs = 0).frameAt(0L))
     }
 
+    @Test
+    fun localVideoIsUsableWithoutStoryboardDimensions() {
+        val preview = VideoSeekPreview.local("content://media/video/42")
+
+        assertTrue(preview.isUsable)
+        assertTrue(preview.isLocal)
+        assertEquals("content://media/video/42", preview.localVideoUri)
+        assertNull(preview.frameAt(12_000L))
+    }
+
     private fun preview(
         pageUrls: List<String> = listOf("page-0", "page-1"),
         totalFrameCount: Int = 18,

--- a/app/src/test/java/com/ivor/ivormusic/ui/downloads/DownloadSizeFormattingTest.kt
+++ b/app/src/test/java/com/ivor/ivormusic/ui/downloads/DownloadSizeFormattingTest.kt
@@ -1,0 +1,13 @@
+package com.ivor.ivormusic.ui.downloads
+
+import org.junit.Assert.assertEquals
+import org.junit.Test
+
+class DownloadSizeFormattingTest {
+
+    @Test
+    fun formatsMediaSizesInBinaryMegabytesAndGigabytes() {
+        assertEquals("7.5 MB", formatDownloadSize((7.5 * 1024 * 1024).toLong()))
+        assertEquals("1.5 GB", formatDownloadSize((1.5 * 1024 * 1024 * 1024).toLong()))
+    }
+}

--- a/app/src/test/java/com/ivor/ivormusic/ui/home/SubscriptionRefreshPolicyTest.kt
+++ b/app/src/test/java/com/ivor/ivormusic/ui/home/SubscriptionRefreshPolicyTest.kt
@@ -1,0 +1,45 @@
+package com.ivor.ivormusic.ui.home
+
+import com.ivor.ivormusic.data.ThemePreferences
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+class SubscriptionRefreshPolicyTest {
+
+    @Test
+    fun localImportsWarmWithoutAnAccount() {
+        assertTrue(
+            shouldWarmSubscriptionFeed(
+                ThemePreferences.SUBSCRIPTIONS_AUTO,
+                hasLocalSubscriptions = true,
+                isLoggedIn = false
+            )
+        )
+        assertTrue(
+            shouldWarmSubscriptionFeed(
+                ThemePreferences.SUBSCRIPTIONS_LOCAL,
+                hasLocalSubscriptions = true,
+                isLoggedIn = false
+            )
+        )
+    }
+
+    @Test
+    fun explicitSourceSelectionIsRespected() {
+        assertFalse(
+            shouldWarmSubscriptionFeed(
+                ThemePreferences.SUBSCRIPTIONS_YOUTUBE,
+                hasLocalSubscriptions = true,
+                isLoggedIn = false
+            )
+        )
+        assertFalse(
+            shouldWarmSubscriptionFeed(
+                ThemePreferences.SUBSCRIPTIONS_LOCAL,
+                hasLocalSubscriptions = false,
+                isLoggedIn = true
+            )
+        )
+    }
+}


### PR DESCRIPTION
## What this changes

<!-- A short description of the change and the problem it solves. Link the issue if there is one. -->

Fixes #

## Why

<!-- What was wrong, or what the feature is for. If the real problem turned out to be a layer below the reported symptom, say so here. -->

## States handled

<!--
For anything user-facing, which of these were considered and what happens in each.
Delete the ones that genuinely do not apply rather than leaving them blank.
-->

- Loading:
- Empty:
- Error / offline:
- Signed out:
- Long titles, missing thumbnail, no artwork colors:

## Deliberately not done

<!-- Anything left out on purpose, and why. This is useful information, not an admission. -->

## Screenshots or recording

<!-- Required for any UI change. Both light and dark if the change touches color or elevation. -->

## Checklist

- [ ] Builds with `./gradlew assembleDebug`
- [ ] Run on a device or emulator, not just compiled
- [ ] No hardcoded colors; everything resolves through `ColorScheme`
- [ ] Material 3 Expressive components used before standard M3, springs for touch-driven motion
- [ ] The signed-out path still works

### If this touches one of these areas

- [ ] **New setting** threaded through all five files (`ThemePreferences`, `ThemeViewModel`, `MainActivity`, `SettingsScreen`, `SettingsPages`) **and added to `buildSettingsSearchIndex`** in `SettingsSearch.kt`. A setting missing from the index is unfindable and there is no compile error to catch it
- [ ] **New player style** added in all four places: the `PlayerStyle` enum, the `<Name>PlayerContent.kt` composable, the `when` in `ExpandablePlayer.kt`, and `playerStyleCatalog`
- [ ] **InnerTube parser change** probed against a live response, not written from memory, with the month and year noted in the KDoc
- [ ] No cookie dumps, response JSON, or `.probe/` contents committed
