### PR TITLE
feat(video): add haptic feedback for 2x speed boost on long press

### DIFF
--- a/app/src/main/java/com/ivor/ivormusic/ui/video/VideoPlayerScreen.kt
+++ b/app/src/main/java/com/ivor/ivormusic/ui/video/VideoPlayerScreen.kt
@@ -1485,6 +1485,7 @@ internal fun PlayerGestureSurface(
                     detectTapGestures(
                         onTap = { onToggleControls() },
                         onLongPress = {
+                            haptics.performHapticFeedback(HapticFeedbackType.LongPress)
                             isBoosting = true
                             onSpeedBoostStart()
                         },


### PR DESCRIPTION
When u long tap on the video for 2x there will be a haptic feedback indicating the same, similar to YT Morphe