### PR TITLE
Use Expressive Wavy seekbar similar to AOSP

### DIFF
--- a/app/src/main/java/com/ivor/ivormusic/MainActivity.kt
+++ b/app/src/main/java/com/ivor/ivormusic/MainActivity.kt
@@ -154,6 +154,7 @@ class MainActivity : ComponentActivity() {
             val timedCommentsEnabled by themeViewModel.timedCommentsEnabled.collectAsState()
             val shortsEnabled by themeViewModel.shortsEnabled.collectAsState()
             val shortsHiddenActions by themeViewModel.shortsHiddenActions.collectAsState()
+            val videoWavySeekBar by themeViewModel.videoWavySeekBar.collectAsState()
             val videoQualityWifi by themeViewModel.videoQualityWifi.collectAsState()
             val videoQualityMobile by themeViewModel.videoQualityMobile.collectAsState()
             val musicQualityWifi by themeViewModel.musicQualityWifi.collectAsState()
@@ -237,6 +238,8 @@ class MainActivity : ComponentActivity() {
                         onShortsEnabledToggle = { themeViewModel.setShortsEnabled(it) },
                         shortsHiddenActions = shortsHiddenActions,
                         onShortsHiddenActionsChange = { themeViewModel.setShortsHiddenActions(it) },
+                        videoWavySeekBar = videoWavySeekBar,
+                        onVideoWavySeekBarToggle = { themeViewModel.setVideoWavySeekBar(it) },
                         videoQualityWifi = videoQualityWifi,
                         onVideoQualityWifiChange = { themeViewModel.setVideoQualityWifi(it) },
                         videoQualityMobile = videoQualityMobile,
@@ -442,6 +445,8 @@ fun MusicApp(
     onShortsEnabledToggle: (Boolean) -> Unit,
     shortsHiddenActions: Set<String>,
     onShortsHiddenActionsChange: (Set<String>) -> Unit,
+    videoWavySeekBar: Boolean = true,
+    onVideoWavySeekBarToggle: (Boolean) -> Unit = {},
     videoQualityWifi: String,
     onVideoQualityWifiChange: (String) -> Unit,
     videoQualityMobile: String,
@@ -780,6 +785,8 @@ fun MusicApp(
                     onShortsEnabledToggle = onShortsEnabledToggle,
                     shortsHiddenActions = shortsHiddenActions,
                     onShortsHiddenActionsChange = onShortsHiddenActionsChange,
+                    videoWavySeekBar = videoWavySeekBar,
+                    onVideoWavySeekBarToggle = onVideoWavySeekBarToggle,
                     videoQualityWifi = videoQualityWifi,
                     onVideoQualityWifiChange = onVideoQualityWifiChange,
                     videoQualityMobile = videoQualityMobile,

--- a/app/src/main/java/com/ivor/ivormusic/data/ThemePreferences.kt
+++ b/app/src/main/java/com/ivor/ivormusic/data/ThemePreferences.kt
@@ -66,6 +66,9 @@ class ThemePreferences(context: Context) {
     private val _shortsHiddenActions = MutableStateFlow(getShortsHiddenActionsPreference())
     val shortsHiddenActions: StateFlow<Set<String>> = _shortsHiddenActions.asStateFlow()
 
+    private val _videoWavySeekBar = MutableStateFlow(getVideoWavySeekBarPreference())
+    val videoWavySeekBar: StateFlow<Boolean> = _videoWavySeekBar.asStateFlow()
+
     private val _videoQualityWifi = MutableStateFlow(getVideoQualityWifiPreference())
     val videoQualityWifi: StateFlow<String> = _videoQualityWifi.asStateFlow()
 
@@ -167,6 +170,7 @@ class ThemePreferences(context: Context) {
             KEY_TIMED_COMMENTS_ENABLED -> _timedCommentsEnabled.value = getTimedCommentsEnabledPreference()
             KEY_SHORTS_ENABLED -> _shortsEnabled.value = getShortsEnabledPreference()
             KEY_SHORTS_HIDDEN_ACTIONS -> _shortsHiddenActions.value = getShortsHiddenActionsPreference()
+            KEY_VIDEO_WAVY_SEEKBAR -> _videoWavySeekBar.value = getVideoWavySeekBarPreference()
             KEY_VIDEO_QUALITY_WIFI -> _videoQualityWifi.value = getVideoQualityWifiPreference()
             KEY_VIDEO_QUALITY_MOBILE -> _videoQualityMobile.value = getVideoQualityMobilePreference()
             KEY_MUSIC_QUALITY_WIFI -> _musicQualityWifi.value = getMusicQualityWifiPreference()
@@ -252,6 +256,7 @@ class ThemePreferences(context: Context) {
         private const val KEY_TIMED_COMMENTS_ENABLED = "timed_comments_enabled"
         private const val KEY_SHORTS_ENABLED = "shorts_enabled"
         private const val KEY_SHORTS_HIDDEN_ACTIONS = "shorts_hidden_actions"
+        private const val KEY_VIDEO_WAVY_SEEKBAR = "video_wavy_seekbar"
 
         /** Ids for the Shorts action-rail buttons that can be hidden. */
         const val SHORTS_ACTION_LIKE = "like"
@@ -839,6 +844,21 @@ class ThemePreferences(context: Context) {
     fun setTimedCommentsEnabled(enabled: Boolean) {
         prefs.edit().putBoolean(KEY_TIMED_COMMENTS_ENABLED, enabled).apply()
         _timedCommentsEnabled.value = enabled
+    }
+
+    /**
+     * Get the stored video wavy seekbar preference. Defaults to true (wavy).
+     */
+    fun getVideoWavySeekBarPreference(): Boolean {
+        return prefs.getBoolean(KEY_VIDEO_WAVY_SEEKBAR, true)
+    }
+
+    /**
+     * Save video wavy seekbar preference and update the flow.
+     */
+    fun setVideoWavySeekBar(enabled: Boolean) {
+        prefs.edit().putBoolean(KEY_VIDEO_WAVY_SEEKBAR, enabled).apply()
+        _videoWavySeekBar.value = enabled
     }
     
     /**

--- a/app/src/main/java/com/ivor/ivormusic/ui/components/ExpressiveSeekBar.kt
+++ b/app/src/main/java/com/ivor/ivormusic/ui/components/ExpressiveSeekBar.kt
@@ -1,0 +1,394 @@
+package com.ivor.ivormusic.ui.components
+
+import androidx.compose.animation.core.LinearEasing
+import androidx.compose.animation.core.RepeatMode
+import androidx.compose.animation.core.Spring
+import androidx.compose.animation.core.animateFloat
+import androidx.compose.animation.core.animateFloatAsState
+import androidx.compose.animation.core.infiniteRepeatable
+import androidx.compose.animation.core.rememberInfiniteTransition
+import androidx.compose.animation.core.spring
+import androidx.compose.animation.core.tween
+import androidx.compose.foundation.Canvas
+import androidx.compose.foundation.gestures.awaitEachGesture
+import androidx.compose.foundation.gestures.awaitFirstDown
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableFloatStateOf
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.rememberUpdatedState
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.geometry.CornerRadius
+import androidx.compose.ui.geometry.Offset
+import androidx.compose.ui.geometry.Size
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.graphics.Path
+import androidx.compose.ui.graphics.StrokeCap
+import androidx.compose.ui.graphics.StrokeJoin
+import androidx.compose.ui.graphics.drawscope.Stroke
+import androidx.compose.ui.hapticfeedback.HapticFeedbackType
+import androidx.compose.ui.input.pointer.pointerInput
+import androidx.compose.ui.platform.LocalDensity
+import androidx.compose.ui.platform.LocalHapticFeedback
+import androidx.compose.ui.unit.Dp
+import androidx.compose.ui.unit.dp
+import com.ivor.ivormusic.data.VideoChapter
+import kotlinx.coroutines.delay
+import kotlin.math.PI
+import kotlin.math.abs
+import kotlin.math.sin
+
+/**
+ * A bespoke Material 3 Expressive wavy seekbar for video playback.
+ *
+ * Designed with:
+ * 1. Global continuous wave phase: Wavy active track flows seamlessly across chapter segments.
+ * 2. Segmented chapter gaps: Clean gaps with smooth rounded ends at each timestamp.
+ * 3. No background bleed: Inactive track is drawn only from the playhead forward (never behind the wave).
+ * 4. Expanding handle (thumb): Scales on touch/scrub with spring physics.
+ * 5. Smooth flattening: Amplitude smoothly animates to 0 when paused or scrubbing.
+ * 6. Haptic chapter boundary feedback.
+ */
+@Composable
+fun ExpressiveSeekBar(
+    progress: Float,
+    onSeek: (Float) -> Unit,
+    modifier: Modifier = Modifier,
+    bufferedProgress: Float = 0f,
+    chapters: List<VideoChapter> = emptyList(),
+    durationMs: Long = 0L,
+    isPlaying: Boolean = false,
+    isWavy: Boolean = true,
+    onTonalSurface: Boolean = false,
+    trackHeight: Dp = 4.5.dp,
+    gapWidth: Dp = 3.5.dp,
+    onScrub: ((Float?) -> Unit)? = null
+) {
+    var isScrubbing by remember { mutableStateOf(false) }
+    var scrubFraction by remember { mutableFloatStateOf(0f) }
+    var pendingSeekFraction by remember { mutableStateOf<Float?>(null) }
+
+    val currentOnSeek by rememberUpdatedState(onSeek)
+    val currentOnScrub by rememberUpdatedState(onScrub)
+
+    // Clear pending seek lock once player's reported progress reaches the seek destination
+    LaunchedEffect(progress) {
+        val pending = pendingSeekFraction
+        if (pending != null && abs(progress - pending) < 0.03f) {
+            pendingSeekFraction = null
+        }
+    }
+
+    // Safety timeout: unlock after 700ms in case progress updates slowly or video is paused
+    LaunchedEffect(pendingSeekFraction) {
+        if (pendingSeekFraction != null) {
+            delay(700)
+            pendingSeekFraction = null
+        }
+    }
+
+    val displayedFraction = (if (isScrubbing) scrubFraction else (pendingSeekFraction ?: progress)).coerceIn(0f, 1f)
+
+    val hapticFeedback = LocalHapticFeedback.current
+    val density = LocalDensity.current
+
+    // Colors
+    val activeColor = MaterialTheme.colorScheme.primary
+    val inactiveTrackColor = if (onTonalSurface) {
+        MaterialTheme.colorScheme.surfaceVariant
+    } else {
+        Color.White.copy(alpha = 0.28f)
+    }
+    val bufferedColor = if (onTonalSurface) {
+        MaterialTheme.colorScheme.onSurfaceVariant.copy(alpha = 0.45f)
+    } else {
+        Color.White.copy(alpha = 0.50f)
+    }
+    val thumbColor = MaterialTheme.colorScheme.primary
+
+    // Wave amplitude: active and wavy when playing (and wavy enabled), flattens cleanly when paused or scrubbing
+    val targetAmplitude = if (isPlaying && !isScrubbing && isWavy) 3.5f else 0f
+    val animatedAmplitude by animateFloatAsState(
+        targetValue = targetAmplitude,
+        animationSpec = spring(
+            dampingRatio = Spring.DampingRatioNoBouncy,
+            stiffness = Spring.StiffnessMedium
+        ),
+        label = "waveAmplitude"
+    )
+
+    // Animated wave phase for continuous playback motion
+    val infiniteTransition = rememberInfiniteTransition(label = "waveTransition")
+    val phase by infiniteTransition.animateFloat(
+        initialValue = 0f,
+        targetValue = (2 * PI).toFloat(),
+        animationSpec = infiniteRepeatable(
+            animation = tween(durationMillis = 1400, easing = LinearEasing),
+            repeatMode = RepeatMode.Restart
+        ),
+        label = "wavePhase"
+    )
+
+    val animatedThumbWidth by animateFloatAsState(
+        targetValue = if (isScrubbing) with(density) { 8.5.dp.toPx() } else with(density) { 4.5.dp.toPx() },
+        animationSpec = spring(dampingRatio = Spring.DampingRatioMediumBouncy),
+        label = "thumbWidth"
+    )
+    val animatedThumbHeight by animateFloatAsState(
+        targetValue = if (isScrubbing) with(density) { 26.dp.toPx() } else with(density) { 18.dp.toPx() },
+        animationSpec = spring(dampingRatio = Spring.DampingRatioMediumBouncy),
+        label = "thumbHeight"
+    )
+
+    val segments = remember(chapters, durationMs) {
+        calculateChapterSegments(chapters, durationMs)
+    }
+
+    Box(
+        modifier = modifier
+            .fillMaxWidth()
+            .height(48.dp)
+            .pointerInput(segments) {
+                awaitEachGesture {
+                    val down = awaitFirstDown(requireUnconsumed = false)
+                    down.consume()
+
+                    val width = size.width.toFloat()
+                    if (width <= 0f) return@awaitEachGesture
+
+                    var currentFraction = (down.position.x / width).coerceIn(0f, 1f)
+                    isScrubbing = true
+                    scrubFraction = currentFraction
+                    currentOnScrub?.invoke(currentFraction)
+
+                    var lastChapter = getChapterIndex(segments, currentFraction)
+                    var isCancelled = false
+                    val pointerId = down.id
+
+                    try {
+                        while (true) {
+                            val event = awaitPointerEvent()
+                            val change = event.changes.firstOrNull { it.id == pointerId } ?: event.changes.firstOrNull()
+
+                            if (change == null) {
+                                isCancelled = true
+                                break
+                            }
+
+                            if (!change.pressed) {
+                                change.consume()
+                                break
+                            }
+
+                            val newFraction = (change.position.x / width).coerceIn(0f, 1f)
+                            change.consume()
+
+                            if (newFraction != currentFraction) {
+                                currentFraction = newFraction
+                                scrubFraction = newFraction
+                                currentOnScrub?.invoke(newFraction)
+
+                                val chapterIndex = getChapterIndex(segments, newFraction)
+                                if (chapterIndex != lastChapter && chapterIndex >= 0) {
+                                    hapticFeedback.performHapticFeedback(HapticFeedbackType.TextHandleMove)
+                                    lastChapter = chapterIndex
+                                }
+                            }
+                        }
+
+                        if (!isCancelled) {
+                            val target = currentFraction
+                            pendingSeekFraction = target
+                            currentOnSeek(target)
+                        } else {
+                            pendingSeekFraction = null
+                        }
+                    } finally {
+                        isScrubbing = false
+                        currentOnScrub?.invoke(null)
+                    }
+                }
+            },
+        contentAlignment = Alignment.Center
+    ) {
+        Canvas(modifier = Modifier.fillMaxSize()) {
+            val width = size.width
+            val height = size.height
+            val centerY = height / 2f
+            val strokePx = trackHeight.toPx()
+            val gapPx = gapWidth.toPx()
+            val wavelengthPx = 28.dp.toPx()
+            val ampPx = animatedAmplitude.dp.toPx()
+
+            val thumbX = (displayedFraction * width).coerceIn(0f, width)
+            val bufferX = (bufferedProgress.coerceIn(0f, 1f) * width).coerceIn(0f, width)
+
+            val trackStroke = Stroke(width = strokePx, cap = StrokeCap.Round, join = StrokeJoin.Round)
+
+            segments.forEachIndexed { index, segment ->
+                val isFirst = index == 0
+                val isLast = index == segments.lastIndex
+
+                val segStartX = segment.startFraction * width + if (isFirst) 0f else gapPx / 2f
+                val segEndX = segment.endFraction * width - if (isLast) 0f else gapPx / 2f
+
+                if (segEndX <= segStartX) return@forEachIndexed
+
+                // 1. INACTIVE TRACK: only drawn in the unplayed region (thumbX to segEndX)
+                if (thumbX < segEndX) {
+                    val inactStart = thumbX.coerceAtLeast(segStartX)
+                    if (segEndX > inactStart) {
+                        drawLine(
+                            color = inactiveTrackColor,
+                            start = Offset(inactStart, centerY),
+                            end = Offset(segEndX, centerY),
+                            strokeWidth = strokePx,
+                            cap = StrokeCap.Round
+                        )
+                    }
+                }
+
+                // 2. BUFFERED TRACK: drawn in the region (thumbX to bufferX) within this segment
+                if (bufferX > thumbX && bufferX > segStartX && thumbX < segEndX) {
+                    val bufStart = thumbX.coerceAtLeast(segStartX)
+                    val bufEnd = bufferX.coerceAtMost(segEndX)
+                    if (bufEnd > bufStart) {
+                        drawLine(
+                            color = bufferedColor,
+                            start = Offset(bufStart, centerY),
+                            end = Offset(bufEnd, centerY),
+                            strokeWidth = strokePx,
+                            cap = StrokeCap.Round
+                        )
+                    }
+                }
+
+                // 3. ACTIVE TRACK: drawn in the played region (segStartX to min(thumbX, segEndX))
+                if (thumbX > segStartX) {
+                    val activeEnd = thumbX.coerceAtMost(segEndX)
+                    if (activeEnd > segStartX) {
+                        // Wave amplitude ramps up smoothly after passing initial distance threshold (1.4 wavelengths)
+                        val minWaveDistance = wavelengthPx * 1.4f
+                        val waveStartRamp = (thumbX / minWaveDistance).coerceIn(0f, 1f)
+                        val effectiveAmpPx = ampPx * waveStartRamp
+
+                        if (effectiveAmpPx > 0.4f) {
+                            // Continuous Wavy Path with global phase alignment
+                            val wavePath = Path()
+                            val stepPx = 2f
+                            var x = segStartX
+                            val startWaveOffset = (x / wavelengthPx) * 2f * PI.toFloat()
+                            wavePath.moveTo(x, centerY + sin(startWaveOffset + phase) * effectiveAmpPx)
+
+                            x += stepPx
+                            while (x <= activeEnd) {
+                                val waveOffset = (x / wavelengthPx) * 2f * PI.toFloat()
+                                val y = centerY + sin(waveOffset + phase) * effectiveAmpPx
+                                wavePath.lineTo(x, y)
+                                x += stepPx
+                            }
+                            // Connect to activeEnd
+                            val endOffset = (activeEnd / wavelengthPx) * 2f * PI.toFloat()
+                            wavePath.lineTo(activeEnd, centerY + sin(endOffset + phase) * effectiveAmpPx)
+
+                            drawPath(
+                                path = wavePath,
+                                color = activeColor,
+                                style = trackStroke
+                            )
+                        } else {
+                            // Flat active track (when paused, scrubbing, or before distance threshold)
+                            drawLine(
+                                color = activeColor,
+                                start = Offset(segStartX, centerY),
+                                end = Offset(activeEnd, centerY),
+                                strokeWidth = strokePx,
+                                cap = StrokeCap.Round
+                            )
+                        }
+                    }
+                }
+            }
+
+            // 4. THUMB / HANDLE (Rounded Rectangular Pill with Size Morphing)
+            val halfThumbW = animatedThumbWidth / 2f
+            val halfThumbH = animatedThumbHeight / 2f
+            val clampedThumbX = thumbX.coerceIn(halfThumbW, width - halfThumbW)
+            val cornerRadius = CornerRadius(halfThumbW, halfThumbW)
+
+            // Outer pill halo when scrubbing
+            if (isScrubbing) {
+                val haloExtra = 5.dp.toPx()
+                val haloW = animatedThumbWidth + haloExtra * 2f
+                val haloH = animatedThumbHeight + haloExtra * 2f
+                drawRoundRect(
+                    color = thumbColor.copy(alpha = 0.25f),
+                    topLeft = Offset(clampedThumbX - haloW / 2f, centerY - haloH / 2f),
+                    size = Size(haloW, haloH),
+                    cornerRadius = CornerRadius(haloW / 2f, haloW / 2f)
+                )
+            }
+
+            // Solid pill handle
+            drawRoundRect(
+                color = thumbColor,
+                topLeft = Offset(clampedThumbX - halfThumbW, centerY - halfThumbH),
+                size = Size(animatedThumbWidth, animatedThumbHeight),
+                cornerRadius = cornerRadius
+            )
+        }
+    }
+}
+
+/** Represents a single visual chapter segment normalized between 0f and 1f. */
+data class ChapterSegment(
+    val startFraction: Float,
+    val endFraction: Float
+)
+
+private fun calculateChapterSegments(chapters: List<VideoChapter>, durationMs: Long): List<ChapterSegment> {
+    if (chapters.size <= 1 || durationMs <= 0L) {
+        return listOf(ChapterSegment(0f, 1f))
+    }
+
+    val sorted = chapters
+        .filter { it.startMs in 0 until durationMs }
+        .sortedBy { it.startMs }
+
+    if (sorted.isEmpty()) {
+        return listOf(ChapterSegment(0f, 1f))
+    }
+
+    val segments = mutableListOf<ChapterSegment>()
+    for (i in sorted.indices) {
+        val startFrac = (sorted[i].startMs.toFloat() / durationMs.toFloat()).coerceIn(0f, 1f)
+        val endFrac = if (i < sorted.lastIndex) {
+            (sorted[i + 1].startMs.toFloat() / durationMs.toFloat()).coerceIn(0f, 1f)
+        } else {
+            1f
+        }
+        if (endFrac > startFrac) {
+            segments.add(ChapterSegment(startFrac, endFrac))
+        }
+    }
+
+    return if (segments.isEmpty()) listOf(ChapterSegment(0f, 1f)) else segments
+}
+
+private fun getChapterIndex(segments: List<ChapterSegment>, fraction: Float): Int {
+    for (i in segments.indices) {
+        if (fraction >= segments[i].startFraction && fraction <= segments[i].endFraction) {
+            return i
+        }
+    }
+    return -1
+}

--- a/app/src/main/java/com/ivor/ivormusic/ui/player/EditorialPlayerContent.kt
+++ b/app/src/main/java/com/ivor/ivormusic/ui/player/EditorialPlayerContent.kt
@@ -50,17 +50,15 @@ import androidx.compose.material.icons.rounded.PlaylistAdd
 import androidx.compose.material.icons.rounded.Smartphone
 import androidx.compose.material3.CircularWavyProgressIndicator
 import androidx.compose.material3.ExperimentalMaterial3ExpressiveApi
+import com.ivor.ivormusic.ui.components.ExpressiveSeekBar
 import androidx.compose.material3.FilledIconButton
 import androidx.compose.material3.Icon
 import androidx.compose.material3.IconButton
 import androidx.compose.material3.IconButtonDefaults
-import androidx.compose.material3.LinearWavyProgressIndicator
 import androidx.compose.material3.LoadingIndicator
 import androidx.compose.material3.MaterialShapes
 import androidx.compose.material3.LocalContentColor
 import androidx.compose.material3.MaterialTheme
-import androidx.compose.material3.Slider
-import androidx.compose.material3.SliderDefaults
 import androidx.compose.material3.Surface
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
@@ -510,55 +508,23 @@ private fun EditorialNowPlayingView(
                 }
 
                 Column(modifier = Modifier.weight(1f)) {
-                    // Scrub locally, seek once on release (streamed tracks
-                    // rebuffer if seeked per drag frame).
-                    var scrubPosition by remember { mutableStateOf<Float?>(null) }
-                    val displayedProgress = scrubPosition?.toLong() ?: progress
+                    var scrubFraction by remember { mutableStateOf<Float?>(null) }
+                    val displayedProgress = scrubFraction?.let { (it * duration).toLong() } ?: progress
                     val progressFraction =
-                        if (duration > 0) displayedProgress.toFloat() / duration.toFloat() else 0f
-                    val animatedProgress by animateFloatAsState(
-                        targetValue = progressFraction,
-                        animationSpec = spring(
-                            dampingRatio = Spring.DampingRatioNoBouncy,
-                            stiffness = Spring.StiffnessLow
-                        ),
-                        label = "EditorialProgress"
-                    )
-                    val lineStroke = Stroke(
-                        width = with(LocalDensity.current) { 4.dp.toPx() },
-                        cap = StrokeCap.Round
-                    )
+                        if (duration > 0) progress.toFloat() / duration.toFloat() else 0f
 
-                    Box(contentAlignment = Alignment.Center) {
-                        // Wavy played portion, flat remainder - the wave
-                        // settles flat when paused.
-                        LinearWavyProgressIndicator(
-                            progress = { animatedProgress },
-                            modifier = Modifier
-                                .fillMaxWidth()
-                                .height(14.dp),
-                            color = accent,
-                            trackColor = accent.copy(alpha = 0.35f),
-                            stroke = lineStroke,
-                            trackStroke = lineStroke,
-                            amplitude = { if (isPlaying) 1f else 0f }
-                        )
-                        Slider(
-                            value = scrubPosition ?: progress.toFloat(),
-                            onValueChange = { scrubPosition = it },
-                            onValueChangeFinished = {
-                                scrubPosition?.let { onSeekTo(it.toLong()) }
-                                scrubPosition = null
-                            },
-                            valueRange = 0f..(duration.toFloat().coerceAtLeast(1f)),
-                            colors = SliderDefaults.colors(
-                                thumbColor = Color.Transparent,
-                                activeTrackColor = Color.Transparent,
-                                inactiveTrackColor = Color.Transparent
-                            ),
-                            modifier = Modifier.fillMaxWidth()
-                        )
-                    }
+                    ExpressiveSeekBar(
+                        progress = progressFraction,
+                        onSeek = { fraction ->
+                            onSeekTo((fraction * duration).toLong())
+                        },
+                        onScrub = { scrubFraction = it },
+                        modifier = Modifier.fillMaxWidth(),
+                        durationMs = duration,
+                        isPlaying = isPlaying,
+                        isWavy = true,
+                        onTonalSurface = false
+                    )
 
                     Row(
                         modifier = Modifier.fillMaxWidth(),

--- a/app/src/main/java/com/ivor/ivormusic/ui/player/GesturePlayerContent.kt
+++ b/app/src/main/java/com/ivor/ivormusic/ui/player/GesturePlayerContent.kt
@@ -63,6 +63,7 @@ import com.ivor.ivormusic.ui.components.queueRowKeys
 import com.ivor.ivormusic.ui.components.rememberQueueRemoval
 import com.ivor.ivormusic.ui.components.rememberQueueReorderState
 import com.ivor.ivormusic.ui.components.SongArtwork
+import com.ivor.ivormusic.ui.components.ExpressiveSeekBar
 import com.ivor.ivormusic.data.LyricsResult
 import java.util.Locale
 import kotlin.math.absoluteValue
@@ -506,50 +507,22 @@ private fun GestureNowPlayingView(
                             modifier = Modifier
                                 .width(progressBarWidth)
                         ) {
-                            // Track the finger locally while scrubbing; seek once on
-                            // release instead of on every drag frame (rebuffer storms).
-                            var scrubPosition by remember { mutableStateOf<Float?>(null) }
-                            val displayedProgress = scrubPosition?.toLong() ?: progress
-                            val progressFraction = if (duration > 0) displayedProgress.toFloat() / duration.toFloat() else 0f
-                            val animatedProgress by animateFloatAsState(
-                                targetValue = progressFraction,
-                                animationSpec = spring(
-                                    dampingRatio = Spring.DampingRatioMediumBouncy,
-                                    stiffness = Spring.StiffnessLow
-                                ),
-                                label = "WavyProgress"
+                            var scrubFraction by remember { mutableStateOf<Float?>(null) }
+                            val displayedProgress = scrubFraction?.let { (it * duration).toLong() } ?: progress
+                            val progressFraction = if (duration > 0) progress.toFloat() / duration.toFloat() else 0f
+
+                            ExpressiveSeekBar(
+                                progress = progressFraction,
+                                onSeek = { fraction ->
+                                    onSeekTo((fraction * duration).toLong())
+                                },
+                                onScrub = { scrubFraction = it },
+                                modifier = Modifier.fillMaxWidth(),
+                                durationMs = duration,
+                                isPlaying = isPlaying,
+                                isWavy = true,
+                                onTonalSurface = !ambientBackground
                             )
-
-                            val thickStroke = Stroke(width = with(LocalDensity.current) { 6.dp.toPx() }, cap = StrokeCap.Round)
-
-                            // Wavy progress with invisible slider overlay for touch
-                            Box(contentAlignment = Alignment.Center) {
-                                LinearWavyProgressIndicator(
-                                    progress = { animatedProgress },
-                                    modifier = Modifier.fillMaxWidth().height(14.dp),
-                                    stroke = thickStroke,
-                                    trackStroke = thickStroke,
-                                    color = primaryColor,
-                                    trackColor = onSurfaceVariantColor.copy(alpha = 0.15f)
-                                )
-
-                                // Invisible slider for touch interaction
-                                Slider(
-                                    value = scrubPosition ?: progress.toFloat(),
-                                    onValueChange = { scrubPosition = it },
-                                    onValueChangeFinished = {
-                                        scrubPosition?.let { onSeekTo(it.toLong()) }
-                                        scrubPosition = null
-                                    },
-                                    valueRange = 0f..(duration.toFloat().coerceAtLeast(1f)),
-                                    colors = SliderDefaults.colors(
-                                        thumbColor = Color.Transparent,
-                                        activeTrackColor = Color.Transparent,
-                                        inactiveTrackColor = Color.Transparent
-                                    ),
-                                    modifier = Modifier.fillMaxWidth()
-                                )
-                            }
 
                             Row(
                                 modifier = Modifier

--- a/app/src/main/java/com/ivor/ivormusic/ui/player/MorphPlayerContent.kt
+++ b/app/src/main/java/com/ivor/ivormusic/ui/player/MorphPlayerContent.kt
@@ -50,18 +50,16 @@ import androidx.compose.material.icons.rounded.PlaylistAdd
 import androidx.compose.material3.CircularWavyProgressIndicator
 import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.ExperimentalMaterial3ExpressiveApi
+import com.ivor.ivormusic.ui.components.ExpressiveSeekBar
 import androidx.compose.material3.FilledIconButton
 import androidx.compose.material3.FloatingToolbarDefaults
 import androidx.compose.material3.HorizontalFloatingToolbar
 import androidx.compose.material3.Icon
 import androidx.compose.material3.IconButtonDefaults
 import androidx.compose.material3.IconToggleButton
-import androidx.compose.material3.LinearWavyProgressIndicator
 import androidx.compose.material3.LoadingIndicator
 import androidx.compose.material3.MaterialShapes
 import androidx.compose.material3.MaterialTheme
-import androidx.compose.material3.Slider
-import androidx.compose.material3.SliderDefaults
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
@@ -333,51 +331,22 @@ fun MorphPlayerSheetContent(
 
                     // ========== SCRUB LINE ==========
                     Column(modifier = Modifier.padding(horizontal = 24.dp)) {
-                        var scrubPosition by remember { mutableStateOf<Float?>(null) }
-                        val displayedProgress = scrubPosition?.toLong() ?: progress
-                        val fraction = if (duration > 0) {
-                            displayedProgress.toFloat() / duration.toFloat()
-                        } else 0f
-                        val animatedFraction by animateFloatAsState(
-                            targetValue = fraction.coerceIn(0f, 1f),
-                            animationSpec = spring(
-                                dampingRatio = Spring.DampingRatioNoBouncy,
-                                stiffness = Spring.StiffnessLow
-                            ),
-                            label = "MorphScrub"
+                        var scrubFraction by remember { mutableStateOf<Float?>(null) }
+                        val displayedProgress = scrubFraction?.let { (it * duration).toLong() } ?: progress
+                        val progressFraction = if (duration > 0) progress.toFloat() / duration.toFloat() else 0f
+
+                        ExpressiveSeekBar(
+                            progress = progressFraction,
+                            onSeek = { fraction ->
+                                viewModel.seekTo((fraction * duration).toLong())
+                            },
+                            onScrub = { scrubFraction = it },
+                            modifier = Modifier.fillMaxWidth(),
+                            durationMs = duration,
+                            isPlaying = isPlaying,
+                            isWavy = true,
+                            onTonalSurface = false
                         )
-                        val lineStroke = Stroke(
-                            width = with(LocalDensity.current) { 3.dp.toPx() },
-                            cap = StrokeCap.Round
-                        )
-                        Box(contentAlignment = Alignment.Center) {
-                            LinearWavyProgressIndicator(
-                                progress = { animatedFraction },
-                                modifier = Modifier
-                                    .fillMaxWidth()
-                                    .height(12.dp),
-                                color = primaryColor,
-                                trackColor = onSurfaceVariantColor.copy(alpha = 0.15f),
-                                stroke = lineStroke,
-                                trackStroke = lineStroke,
-                                amplitude = { if (isPlaying) 1f else 0f }
-                            )
-                            Slider(
-                                value = scrubPosition ?: progress.toFloat(),
-                                onValueChange = { scrubPosition = it },
-                                onValueChangeFinished = {
-                                    scrubPosition?.let { viewModel.seekTo(it.toLong()) }
-                                    scrubPosition = null
-                                },
-                                valueRange = 0f..(duration.toFloat().coerceAtLeast(1f)),
-                                colors = SliderDefaults.colors(
-                                    thumbColor = Color.Transparent,
-                                    activeTrackColor = Color.Transparent,
-                                    inactiveTrackColor = Color.Transparent
-                                ),
-                                modifier = Modifier.fillMaxWidth()
-                            )
-                        }
                         Row(
                             modifier = Modifier.fillMaxWidth(),
                             horizontalArrangement = Arrangement.SpaceBetween

--- a/app/src/main/java/com/ivor/ivormusic/ui/player/PlayerSheetContent.kt
+++ b/app/src/main/java/com/ivor/ivormusic/ui/player/PlayerSheetContent.kt
@@ -56,6 +56,7 @@ import com.ivor.ivormusic.ui.components.rememberQueueRemoval
 import com.ivor.ivormusic.ui.components.rememberQueueReorderState
 import com.ivor.ivormusic.ui.components.SongArtwork
 import com.ivor.ivormusic.data.LyricsResult
+import com.ivor.ivormusic.ui.components.ExpressiveSeekBar
 
 /**
  *  Material 3 Expressive Music Player
@@ -485,51 +486,23 @@ private fun ExpressiveNowPlayingView(
                 .padding(bottom = 40.dp),
             horizontalAlignment = Alignment.CenterHorizontally
         ) {
-            // 🌟 Wavy Progress Indicator (Expressive!)
-            // While the user is scrubbing we only track the finger locally and
-            // issue a single seek on release — seeking on every drag frame causes
-            // rebuffering storms on streamed tracks.
-            var scrubPosition by remember { mutableStateOf<Float?>(null) }
-            val displayedProgress = scrubPosition?.toLong() ?: progress
-            Box(contentAlignment = Alignment.Center) {
-                val progressFraction = if (duration > 0) displayedProgress.toFloat() / duration.toFloat() else 0f
-                val animatedProgress by animateFloatAsState(
-                    targetValue = progressFraction,
-                    animationSpec = spring(
-                        dampingRatio = Spring.DampingRatioMediumBouncy,
-                        stiffness = Spring.StiffnessLow
-                    ),
-                    label = "Progress"
-                )
+            // 🌟 Wavy Progress Indicator with Expressive Thumb Handle
+            var scrubFraction by remember { mutableStateOf<Float?>(null) }
+            val displayedProgress = scrubFraction?.let { (it * duration).toLong() } ?: progress
+            val progressFraction = if (duration > 0) progress.toFloat() / duration.toFloat() else 0f
 
-                val thickStroke = Stroke(width = with(LocalDensity.current) { 6.dp.toPx() }, cap = StrokeCap.Round)
-
-                LinearWavyProgressIndicator(
-                    progress = { animatedProgress },
-                    modifier = Modifier.fillMaxWidth().height(14.dp),
-                    stroke = thickStroke,
-                    trackStroke = thickStroke,
-                    color = primaryColor,
-                    trackColor = onSurfaceVariantColor.copy(alpha = 0.15f)
-                )
-
-                // Invisible slider for touch interaction
-                Slider(
-                    value = scrubPosition ?: progress.toFloat(),
-                    onValueChange = { scrubPosition = it },
-                    onValueChangeFinished = {
-                        scrubPosition?.let { onSeekTo(it.toLong()) }
-                        scrubPosition = null
-                    },
-                    valueRange = 0f..(duration.toFloat().coerceAtLeast(1f)),
-                    colors = SliderDefaults.colors(
-                        thumbColor = Color.Transparent,
-                        activeTrackColor = Color.Transparent,
-                        inactiveTrackColor = Color.Transparent
-                    ),
-                    modifier = Modifier.fillMaxWidth()
-                )
-            }
+            ExpressiveSeekBar(
+                progress = progressFraction,
+                onSeek = { fraction ->
+                    onSeekTo((fraction * duration).toLong())
+                },
+                onScrub = { scrubFraction = it },
+                modifier = Modifier.fillMaxWidth(),
+                durationMs = duration,
+                isPlaying = isPlaying,
+                isWavy = true,
+                onTonalSurface = !ambientBackground
+            )
 
             // Time Labels
             Row(

--- a/app/src/main/java/com/ivor/ivormusic/ui/player/StickerPlayerContent.kt
+++ b/app/src/main/java/com/ivor/ivormusic/ui/player/StickerPlayerContent.kt
@@ -45,13 +45,11 @@ import androidx.compose.material.icons.rounded.Lyrics
 import androidx.compose.material.icons.rounded.MusicNote
 import androidx.compose.material.icons.rounded.PlaylistAdd
 import androidx.compose.material3.ExperimentalMaterial3ExpressiveApi
+import com.ivor.ivormusic.ui.components.ExpressiveSeekBar
 import androidx.compose.material3.Icon
-import androidx.compose.material3.LinearWavyProgressIndicator
 import androidx.compose.material3.LoadingIndicator
 import androidx.compose.material3.MaterialShapes
 import androidx.compose.material3.MaterialTheme
-import androidx.compose.material3.Slider
-import androidx.compose.material3.SliderDefaults
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
@@ -344,51 +342,22 @@ fun StickerPlayerSheetContent(
 
                     // ========== PROGRESS ==========
                     Column(modifier = Modifier.padding(horizontal = 24.dp)) {
-                        var scrubPosition by remember { mutableStateOf<Float?>(null) }
-                        val displayedProgress = scrubPosition?.toLong() ?: progress
-                        val fraction = if (duration > 0) {
-                            displayedProgress.toFloat() / duration.toFloat()
-                        } else 0f
-                        val animatedFraction by animateFloatAsState(
-                            targetValue = fraction.coerceIn(0f, 1f),
-                            animationSpec = spring(
-                                dampingRatio = Spring.DampingRatioNoBouncy,
-                                stiffness = Spring.StiffnessLow
-                            ),
-                            label = "StickerProgress"
+                        var scrubFraction by remember { mutableStateOf<Float?>(null) }
+                        val displayedProgress = scrubFraction?.let { (it * duration).toLong() } ?: progress
+                        val progressFraction = if (duration > 0) progress.toFloat() / duration.toFloat() else 0f
+
+                        ExpressiveSeekBar(
+                            progress = progressFraction,
+                            onSeek = { fraction ->
+                                viewModel.seekTo((fraction * duration).toLong())
+                            },
+                            onScrub = { scrubFraction = it },
+                            modifier = Modifier.fillMaxWidth(),
+                            durationMs = duration,
+                            isPlaying = isPlaying,
+                            isWavy = true,
+                            onTonalSurface = false
                         )
-                        val lineStroke = Stroke(
-                            width = with(LocalDensity.current) { 4.dp.toPx() },
-                            cap = StrokeCap.Round
-                        )
-                        Box(contentAlignment = Alignment.Center) {
-                            LinearWavyProgressIndicator(
-                                progress = { animatedFraction },
-                                modifier = Modifier
-                                    .fillMaxWidth()
-                                    .height(14.dp),
-                                color = accent,
-                                trackColor = inkVariant.copy(alpha = 0.25f),
-                                stroke = lineStroke,
-                                trackStroke = lineStroke,
-                                amplitude = { if (isPlaying) 1f else 0f }
-                            )
-                            Slider(
-                                value = scrubPosition ?: progress.toFloat(),
-                                onValueChange = { scrubPosition = it },
-                                onValueChangeFinished = {
-                                    scrubPosition?.let { viewModel.seekTo(it.toLong()) }
-                                    scrubPosition = null
-                                },
-                                valueRange = 0f..(duration.toFloat().coerceAtLeast(1f)),
-                                colors = SliderDefaults.colors(
-                                    thumbColor = Color.Transparent,
-                                    activeTrackColor = Color.Transparent,
-                                    inactiveTrackColor = Color.Transparent
-                                ),
-                                modifier = Modifier.fillMaxWidth()
-                            )
-                        }
                         Row(
                             modifier = Modifier.fillMaxWidth(),
                             horizontalArrangement = Arrangement.SpaceBetween

--- a/app/src/main/java/com/ivor/ivormusic/ui/settings/SettingsPages.kt
+++ b/app/src/main/java/com/ivor/ivormusic/ui/settings/SettingsPages.kt
@@ -671,6 +671,8 @@ internal fun ContentSettingsPage(
     onShortsEnabledToggle: (Boolean) -> Unit,
     shortsHiddenActions: Set<String>,
     onShowShortsButtons: () -> Unit,
+    videoWavySeekBar: Boolean = true,
+    onVideoWavySeekBarToggle: (Boolean) -> Unit = {},
     onNavigateToNotInterested: () -> Unit,
     onBack: () -> Unit
 ) {
@@ -781,6 +783,20 @@ internal fun ContentSettingsPage(
                                 )
                             }
                         }
+
+                        SettingsDivider()
+
+                        SettingsToggleRow(
+                            icon = Icons.Rounded.GraphicEq,
+                            title = "Wavy seekbar",
+                            subtitle = if (videoWavySeekBar) {
+                                "Wavy playback animation on the video seekbar"
+                            } else {
+                                "Straight linear video seekbar"
+                            },
+                            enabled = videoWavySeekBar,
+                            onToggle = onVideoWavySeekBarToggle
+                        )
                     }
                 }
             }

--- a/app/src/main/java/com/ivor/ivormusic/ui/settings/SettingsScreen.kt
+++ b/app/src/main/java/com/ivor/ivormusic/ui/settings/SettingsScreen.kt
@@ -280,6 +280,8 @@ fun SettingsScreen(
     onShortsEnabledToggle: (Boolean) -> Unit,
     shortsHiddenActions: Set<String> = emptySet(),
     onShortsHiddenActionsChange: (Set<String>) -> Unit = {},
+    videoWavySeekBar: Boolean = true,
+    onVideoWavySeekBarToggle: (Boolean) -> Unit = {},
     videoQualityWifi: String,
     onVideoQualityWifiChange: (String) -> Unit,
     videoQualityMobile: String,
@@ -725,6 +727,8 @@ fun SettingsScreen(
                     onShortsEnabledToggle = onShortsEnabledToggle,
                     shortsHiddenActions = shortsHiddenActions,
                     onShowShortsButtons = { showShortsButtonsDialog = true },
+                    videoWavySeekBar = videoWavySeekBar,
+                    onVideoWavySeekBarToggle = onVideoWavySeekBarToggle,
                     onNavigateToNotInterested = onNavigateToNotInterested,
                     onBack = { page = SettingsPage.HUB }
                 )

--- a/app/src/main/java/com/ivor/ivormusic/ui/settings/SettingsSearch.kt
+++ b/app/src/main/java/com/ivor/ivormusic/ui/settings/SettingsSearch.kt
@@ -311,6 +311,10 @@ internal fun buildSettingsSearchIndex(
         listOf("hide buttons", "like", "share", "overlay", "actions")
     ) { onShowShortsButtons() }
     entry(
+        "video_wavy_seekbar", "Wavy seekbar", "Content and feeds", Icons.Rounded.GraphicEq,
+        listOf("wavy", "seekbar", "seek bar", "slider", "video seekbar", "wave", "waves", "progress bar", "normal seekbar")
+    ) { onOpenPage(SettingsPage.CONTENT) }
+    entry(
         "not_interested", "Not Recommended", "Content and feeds", Icons.Rounded.NotInterested,
         listOf(
             "blocked", "hidden", "not interested", "blocklist", "dont recommend",

--- a/app/src/main/java/com/ivor/ivormusic/ui/theme/ThemeViewModel.kt
+++ b/app/src/main/java/com/ivor/ivormusic/ui/theme/ThemeViewModel.kt
@@ -32,6 +32,7 @@ class ThemeViewModel(application: Application) : AndroidViewModel(application) {
     val timedCommentsEnabled: StateFlow<Boolean> = themePreferences.timedCommentsEnabled
     val shortsEnabled: StateFlow<Boolean> = themePreferences.shortsEnabled
     val shortsHiddenActions: StateFlow<Set<String>> = themePreferences.shortsHiddenActions
+    val videoWavySeekBar: StateFlow<Boolean> = themePreferences.videoWavySeekBar
     val videoQualityWifi: StateFlow<String> = themePreferences.videoQualityWifi
     val videoQualityMobile: StateFlow<String> = themePreferences.videoQualityMobile
     val musicQualityWifi: StateFlow<String> = themePreferences.musicQualityWifi
@@ -139,6 +140,10 @@ class ThemeViewModel(application: Application) : AndroidViewModel(application) {
 
     fun setShortsHiddenActions(hidden: Set<String>) {
         themePreferences.setShortsHiddenActions(hidden)
+    }
+
+    fun setVideoWavySeekBar(enabled: Boolean) {
+        themePreferences.setVideoWavySeekBar(enabled)
     }
 
     fun setVideoQualityWifi(quality: String) {

--- a/app/src/main/java/com/ivor/ivormusic/ui/video/VerticalLivePlayerContent.kt
+++ b/app/src/main/java/com/ivor/ivormusic/ui/video/VerticalLivePlayerContent.kt
@@ -556,6 +556,7 @@ fun VerticalLivePlayerContent(
                                 durationMs = duration,
                                 showSeekPreview = false,
                                 onScrubbingChanged = onScrubbingChanged,
+                                isPlaying = isPlaying,
                                 onTonalSurface = true
                             )
                             LiveEdgeChip(

--- a/app/src/main/java/com/ivor/ivormusic/ui/video/VideoPlayerScreen.kt
+++ b/app/src/main/java/com/ivor/ivormusic/ui/video/VideoPlayerScreen.kt
@@ -99,11 +99,10 @@ import androidx.compose.material3.ListItemDefaults
 import androidx.compose.material3.LoadingIndicator
 import androidx.compose.material3.MaterialShapes
 import androidx.compose.material3.MaterialTheme
-import androidx.compose.material3.Slider
-import androidx.compose.material3.SliderDefaults
 import androidx.compose.material3.Surface
 import androidx.compose.material3.Text
 import androidx.compose.material3.VerticalDivider
+import com.ivor.ivormusic.ui.components.ExpressiveSeekBar
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.CompositionLocalProvider
 import androidx.compose.runtime.collectAsState
@@ -607,6 +606,7 @@ fun FullscreenPlayerContent(
                             seekPreview = seekPreview,
                             showSeekPreview = !isLive,
                             onScrubbingChanged = onScrubbingChanged,
+                            isPlaying = isPlaying
                         )
 
                         if (isLive) {
@@ -874,6 +874,7 @@ fun PortraitPlayerContent(
                             seekPreview = seekPreview,
                             showSeekPreview = !isLive,
                             onScrubbingChanged = onScrubbingChanged,
+                            isPlaying = isPlaying
                         )
 
                         if (isLive) {
@@ -900,11 +901,6 @@ fun PortraitPlayerContent(
  */
 internal const val LIVE_EDGE_THRESHOLD = 0.995f
 
-/** Time distance close enough to confirm that the position poll observed a seek. */
-private const val SEEK_CONFIRM_TOLERANCE_MS = 1_000f
-
-/** Backstop for failed or heavily rounded seeks; prevents a stale optimistic thumb. */
-private const val SEEK_COMMIT_TIMEOUT_MS = 1_500L
 
 /**
  * The "LIVE" marker where a normal video shows its duration. Red and tappable
@@ -953,21 +949,14 @@ internal fun LiveEdgeChip(
 }
 
 /**
- * Scrubbing seek bar. While the user drags, the thumb follows a local value and
- * the player is NOT touched, so we don't kick off a buffer/fetch on every pixel.
- * The actual seek fires once, on release (onValueChangeFinished). The 500ms
- * progress poll from the parent is ignored during the drag to avoid the thumb
- * fighting the finger.
+ * Expressive wavy seek bar for video playback. While the user drags, the thumb follows
+ * a local value and the player is NOT touched until release.
  *
- * [onTonalSurface] switches the track and tick colors from the white-on-video
- * set to ColorScheme roles. The standard player draws this straight onto the
- * frame, where white is the only thing that reads on any video; the vertical
- * live player floats it inside a surfaceContainer, where white would disappear
- * in a light theme.
+ * [onTonalSurface] switches track colors for tonal containers (e.g. vertical live player).
  */
 @Composable
 internal fun PlayerSeekBar(
-    mediaId: String,
+    mediaId: String = "",
     progress: Float,
     onSeek: (Float) -> Unit,
     modifier: Modifier = Modifier,
@@ -977,131 +966,42 @@ internal fun PlayerSeekBar(
     seekPreview: VideoSeekPreview? = null,
     showSeekPreview: Boolean = true,
     onScrubbingChanged: (Boolean) -> Unit = {},
+    isPlaying: Boolean = false,
+    isWavy: Boolean = true,
+    gapWidth: Dp = 8.dp,
     onTonalSurface: Boolean = false
 ) {
-    var isScrubbing by remember(mediaId) { mutableStateOf(false) }
-    var scrubValue by remember(mediaId) { mutableFloatStateOf(0f) }
-    var committedSeekValue by remember(mediaId) { mutableStateOf<Float?>(null) }
-    val currentScrubbingChanged by rememberUpdatedState(onScrubbingChanged)
-    val externalProgress = progress.coerceIn(0f, 1f)
-    val displayedProgress = when {
-        isScrubbing -> scrubValue
-        committedSeekValue != null -> committedSeekValue ?: externalProgress
-        else -> externalProgress
-    }
+    val context = LocalContext.current
+    val themePreferences = remember(context) { ThemePreferences(context) }
+    val wavySetting by themePreferences.videoWavySeekBar.collectAsState()
 
-    // A seek changes ExoPlayer immediately, but the StateFlow feeding this
-    // composable is sampled twice a second. Hold the committed value until the
-    // poll catches up so the thumb never flashes back to the pre-seek position.
-    LaunchedEffect(externalProgress, mediaId) {
-        val target = committedSeekValue ?: return@LaunchedEffect
-        val distanceMs = abs(externalProgress - target) * durationMs.toFloat()
-        if (distanceMs <= SEEK_CONFIRM_TOLERANCE_MS) {
-            committedSeekValue = null
-        }
-    }
-    LaunchedEffect(committedSeekValue, mediaId) {
-        val target = committedSeekValue ?: return@LaunchedEffect
-        delay(SEEK_COMMIT_TIMEOUT_MS)
-        if (committedSeekValue == target) committedSeekValue = null
-    }
+    var scrubFraction by remember(mediaId) { mutableStateOf<Float?>(null) }
+    val currentScrubbingChanged by rememberUpdatedState(onScrubbingChanged)
+
     DisposableEffect(mediaId) {
         onDispose { currentScrubbingChanged(false) }
     }
 
-    val bufferedColor = if (onTonalSurface) {
-        MaterialTheme.colorScheme.onSurfaceVariant.copy(alpha = 0.55f)
-    } else {
-        Color.White.copy(alpha = 0.35f)
-    }
-    val inactiveTrackColor = if (onTonalSurface) {
-        MaterialTheme.colorScheme.surfaceVariant
-    } else {
-        Color.White.copy(0.3f)
-    }
-    val tickColor = if (onTonalSurface) {
-        MaterialTheme.colorScheme.onSurface.copy(alpha = 0.85f)
-    } else {
-        Color.Black.copy(alpha = 0.85f)
-    }
-    val sliderColors = SliderDefaults.colors(
-        thumbColor = MaterialTheme.colorScheme.primary,
-        activeTrackColor = MaterialTheme.colorScheme.primary,
-        inactiveTrackColor = inactiveTrackColor
-    )
-
-    // Keep the control's measured height identical before and during a drag.
-    // The preview is an overlay: its negative offset changes where it draws,
-    // not the space the bottom controls reserve for this seek bar.
     BoxWithConstraints(modifier = modifier.height(48.dp)) {
-        Slider(
-            value = displayedProgress,
-            onValueChange = {
-                if (!isScrubbing) {
-                    isScrubbing = true
-                    committedSeekValue = null
-                    onScrubbingChanged(true)
-                }
-                scrubValue = it
-            },
-            onValueChangeFinished = {
-                if (isScrubbing) {
-                    val target = scrubValue.coerceIn(0f, 1f)
-                    committedSeekValue = target
-                    onSeek(target)
-                }
-                isScrubbing = false
-                onScrubbingChanged(false)
-            },
-            enabled = durationMs > 0L,
-            colors = sliderColors,
-            track = { sliderState ->
-                // The track slot is measured to the slider's actual travel
-                // width and placed half a thumb in from either edge. Drawing
-                // buffer and chapter marks here keeps them on the same geometry
-                // as the gesture, instead of using the wider 48dp touch target.
-                Box {
-                    SliderDefaults.Track(
-                        sliderState = sliderState,
-                        enabled = durationMs > 0L,
-                        colors = sliderColors,
-                    )
-                    Canvas(modifier = Modifier.matchParentSize()) {
-                        val centerY = size.height / 2f
-                        val buffered = bufferedProgress.coerceIn(0f, 1f)
-                        if (buffered > displayedProgress) {
-                            drawLine(
-                                color = bufferedColor,
-                                start = Offset(displayedProgress * size.width, centerY),
-                                end = Offset(buffered * size.width, centerY),
-                                strokeWidth = 4.dp.toPx(),
-                                cap = StrokeCap.Round,
-                            )
-                        }
-
-                        if (chapters.size > 1 && durationMs > 0L) {
-                            val half = 5.dp.toPx()
-                            val stroke = 2.5.dp.toPx()
-                            chapters.forEach { chapter ->
-                                val fraction = chapter.startMs.toFloat() / durationMs.toFloat()
-                                if (fraction > 0.001f && fraction < 0.999f) {
-                                    val x = fraction * size.width
-                                    drawLine(
-                                        color = tickColor,
-                                        start = Offset(x, centerY - half),
-                                        end = Offset(x, centerY + half),
-                                        strokeWidth = stroke,
-                                    )
-                                }
-                            }
-                        }
-                    }
-                }
-            },
-            modifier = Modifier.fillMaxWidth()
+        ExpressiveSeekBar(
+            progress = progress,
+            onSeek = onSeek,
+            modifier = Modifier.fillMaxWidth(),
+            bufferedProgress = bufferedProgress,
+            chapters = chapters,
+            durationMs = durationMs,
+            isPlaying = isPlaying,
+            isWavy = isWavy && wavySetting,
+            gapWidth = gapWidth,
+            onTonalSurface = onTonalSurface,
+            onScrub = { fraction ->
+                scrubFraction = fraction
+                currentScrubbingChanged(fraction != null)
+            }
         )
 
-        if (showSeekPreview && isScrubbing && durationMs > 0L) {
+        if (showSeekPreview && scrubFraction != null && durationMs > 0L) {
+            val scrubValue = scrubFraction!!
             val previewWidth = if (seekPreview?.isUsable == true) 144.dp else 72.dp
             val previewX = (maxWidth * scrubValue - previewWidth / 2)
                 .coerceIn(0.dp, (maxWidth - previewWidth).coerceAtLeast(0.dp))
@@ -1118,7 +1018,6 @@ internal fun PlayerSeekBar(
                     .wrapContentSize(Alignment.TopStart, unbounded = true)
             )
         }
-
     }
 }
 
@@ -1204,6 +1103,7 @@ private fun SeekPreviewCard(
         }
     }
 }
+
 
 /**
  * Pill above the seek bar showing the current chapter title; tapping it opens


### PR DESCRIPTION
<img width="2424" height="1080" alt="Screenshot_20260824-005117" src="https://github.com/user-attachments/assets/ea33fcf9-07e8-4860-8550-5ec3f046159e" />
<img width="2424" height="1080" alt="Screenshot_20260824-005144" src="https://github.com/user-attachments/assets/93060ead-5c1f-4e83-bdf8-a286ca083903" />
<img width="2424" height="1080" alt="Screenshot_20260824-005156" src="https://github.com/user-attachments/assets/3f13bcb0-24b3-4801-bb72-8df8aaafe6ce" />
<img width="2424" height="1080" alt="Screenshot_20260824-005224" src="https://github.com/user-attachments/assets/9301fda0-ebc3-4f0f-b1e5-cb0bb0e6e632" />


This changes the default LinearWavyProgressIndicator which is a standard replacement for seekbar with a ExpressiveSeekbar variant similar to Squiggle Seekbar implementation of AOSP, unlike LinearWavyProgressIndicator it has a handle for interaction which is like Better UX 101, along with that the user can also disable the wavy variant if they want the normal seekbar for the video content mode
The M3E Slider is not a great option for the video mode as it looks kinda weird and bad TBH 
There was AI Involved in the implementation!!