### PR TITLE
feat(player): improve transport play button shape in expressive player

### DIFF
--- a/app/src/main/java/com/ivor/ivormusic/ui/player/PlayerSheetContent.kt
+++ b/app/src/main/java/com/ivor/ivormusic/ui/player/PlayerSheetContent.kt
@@ -31,6 +31,7 @@ import androidx.compose.material.icons.rounded.Lyrics
 import androidx.compose.material.icons.automirrored.filled.QueueMusic
 import androidx.compose.material.icons.rounded.PlaylistAdd
 import androidx.compose.material3.*
+import androidx.compose.material3.toShape
 import androidx.compose.runtime.*
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
@@ -586,6 +587,9 @@ private fun ExpressiveNowPlayingView(
             val playInteraction = remember { MutableInteractionSource() }
             val nextInteraction = remember { MutableInteractionSource() }
             val repeatInteraction = remember { MutableInteractionSource() }
+            val pausedPlayShapes = IconButtonDefaults.shapes(
+                shape = MaterialShapes.Square.toShape()
+            )
 
             ButtonGroup(
                 // The five transport buttons are weighted to fill the row exactly, so the
@@ -650,7 +654,7 @@ private fun ExpressiveNowPlayingView(
                                 playerHaptics.playPause(!viewModel.isPlaying.value)
                                 viewModel.togglePlayPause()
                             },
-                            shapes = stableShapes,
+                            shapes = if (isPlaying) stableShapes else pausedPlayShapes,
                             interactionSource = playInteraction,
                             colors = IconButtonDefaults.filledIconButtonColors(
                                 containerColor = primaryContainerColor,


### PR DESCRIPTION
<img width="1080" height="301" alt="Screenshot_20260824-005952~2" src="https://github.com/user-attachments/assets/3d4b6a94-3c0e-404d-baed-71c072171fc5" />
<img width="1080" height="363" alt="Screenshot_20260824-005949~2" src="https://github.com/user-attachments/assets/278ce58e-59cd-4590-a2b0-0046eb196123" />

The Play/Pause button has a distinct looks for more M3E Feels