### PR TITLE
Add Shorts in the search result and Double tap to like in shorts

### DIFF
--- a/app/src/main/java/com/ivor/ivormusic/data/YouTubeRepository.kt
+++ b/app/src/main/java/com/ivor/ivormusic/data/YouTubeRepository.kt
@@ -3460,6 +3460,25 @@ class YouTubeRepository(private val context: Context) {
     }
 
     /**
+     * Search for Shorts matching [query] (used for the search results Shorts shelf
+     * and the Shorts search category).
+     */
+    suspend fun searchShorts(query: String): List<ShortsItem> = withContext(Dispatchers.IO) {
+        if (query.isBlank()) return@withContext emptyList()
+        try {
+            val effectiveQuery = if (query.contains("shorts", ignoreCase = true)) query else "$query shorts"
+            val body = org.json.JSONObject()
+                .put("context", webContext())
+                .put("query", effectiveQuery)
+            val raw = postWatchApi("search", body) ?: return@withContext emptyList()
+            parseShortsLockups(org.json.JSONObject(raw))
+        } catch (e: Exception) {
+            android.util.Log.e("YouTubeRepo", "searchShorts failed", e)
+            emptyList()
+        }
+    }
+
+    /**
      * One page of the endless swipe feed from reel/reel_watch_sequence.
      * [sequenceParams] is either a shelf item's seed params or the
      * continuation token of a previous page (the endpoint accepts both in

--- a/app/src/main/java/com/ivor/ivormusic/ui/home/HomeScreen.kt
+++ b/app/src/main/java/com/ivor/ivormusic/ui/home/HomeScreen.kt
@@ -679,6 +679,7 @@ fun HomeScreen(
                         },
                         onPlayVideoQueue = onPlayVideoQueue,
                         onEnqueueVideo = onEnqueueVideo,
+                        onOpenShorts = onOpenShorts,
                         onProfileClick = onProfileClick,
                         onOpenChannel = onOpenChannel,
                         onSongLongPress = { song -> songOptionsTarget = song },
@@ -686,6 +687,7 @@ fun HomeScreen(
                         viewModel = viewModel,
                         isDarkMode = isDarkMode,
                         videoMode = videoMode,
+                        shortsEnabled = shortsEnabled,
                         localOnly = localOnly,
                         listState = searchScrollState
                     )
@@ -1912,6 +1914,7 @@ fun SearchContent(
      */
     onPlayVideoQueue: ((com.ivor.ivormusic.data.VideoQueue) -> Unit)? = null,
     onEnqueueVideo: ((com.ivor.ivormusic.data.VideoItem, Boolean) -> Unit)? = null,
+    onOpenShorts: (List<com.ivor.ivormusic.data.ShortsItem>, Int) -> Unit = { _, _ -> },
     onProfileClick: () -> Unit = {},
     /** Open a creator's page, from a Channels result or the long-press sheet. */
     onOpenChannel: (String) -> Unit = {},
@@ -1919,6 +1922,7 @@ fun SearchContent(
     viewModel: HomeViewModel,
     isDarkMode: Boolean,
     videoMode: Boolean = false,
+    shortsEnabled: Boolean = false,
     localOnly: Boolean = false,
     onSongLongPress: ((Song) -> Unit)? = null,
     /** Hoisted by HomeScreen: survives tab switches, reachable by the nav bar. */
@@ -1968,12 +1972,14 @@ fun SearchContent(
                 },
                 onProfileClick = onProfileClick,
                 onEnqueueVideo = onEnqueueVideo,
+                onOpenShorts = onOpenShorts,
                 onOpenChannel = onOpenChannel,
                 onSongLongPress = onSongLongPress,
                 contentPadding = contentPadding,
                 viewModel = viewModel,
                 isDarkMode = isDarkMode,
                 videoMode = videoMode,
+                shortsEnabled = shortsEnabled,
                 localOnly = localOnly,
                 listState = listState
             )

--- a/app/src/main/java/com/ivor/ivormusic/ui/home/HomeViewModel.kt
+++ b/app/src/main/java/com/ivor/ivormusic/ui/home/HomeViewModel.kt
@@ -1687,6 +1687,18 @@ class HomeViewModel(application: Application) : AndroidViewModel(application) {
     }
 
     /**
+     * Search for YouTube Shorts (for video mode search).
+     */
+    suspend fun searchShorts(query: String): List<com.ivor.ivormusic.data.ShortsItem> {
+        if (query.isBlank()) return emptyList()
+        return try {
+            youtubeRepository.searchShorts(query)
+        } catch (e: Exception) {
+            emptyList()
+        }
+    }
+
+    /**
      * A creator's channel identity - banner, avatar, verified tick, subscriber
      * count - for the music artist page.
      *

--- a/app/src/main/java/com/ivor/ivormusic/ui/search/SearchScreen.kt
+++ b/app/src/main/java/com/ivor/ivormusic/ui/search/SearchScreen.kt
@@ -138,13 +138,17 @@ import androidx.compose.ui.graphics.Outline
 import androidx.compose.material.icons.rounded.History
 import androidx.compose.material.icons.rounded.Close
 import androidx.compose.material.icons.rounded.Link
+import androidx.compose.material.icons.rounded.Bolt
 import androidx.compose.material.icons.rounded.LinkOff
 import androidx.compose.material.icons.rounded.PlaylistPlay
 import androidx.compose.material.icons.rounded.Refresh
 import androidx.compose.material.icons.rounded.Search
 import androidx.compose.material.icons.automirrored.rounded.PlaylistPlay
+import com.ivor.ivormusic.data.ShortsItem
+import com.ivor.ivormusic.ui.video.ShortsShelf
 import com.ivor.ivormusic.ui.video.VideoCard
 import com.ivor.ivormusic.ui.video.VideoOptionsSheetHost
+import kotlinx.coroutines.async
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.launch
 
@@ -193,6 +197,8 @@ fun SearchScreen(
     onSongLongPress: ((Song) -> Unit)? = null,
     /** Queue a video result, next or at the end. */
     onEnqueueVideo: ((VideoItem, Boolean) -> Unit)? = null,
+    /** Open shorts at the given index from a shelf or result list. */
+    onOpenShorts: (List<ShortsItem>, Int) -> Unit = { _, _ -> },
     /**
      * Play a single YouTube result and continue into its radio. Used instead of
      * [onPlayQueue] for loose result lists, where the neighbouring entries are
@@ -211,6 +217,7 @@ fun SearchScreen(
     viewModel: HomeViewModel,
     isDarkMode: Boolean,
     videoMode: Boolean = false,
+    shortsEnabled: Boolean = false,
     localOnly: Boolean = false,
     modifier: Modifier = Modifier,
     /**
@@ -238,6 +245,7 @@ fun SearchScreen(
     var videoResultsExhausted by remember { mutableStateOf(false) }
     var youtubeResults by remember { mutableStateOf<List<Song>>(emptyList()) }
     var videoResults by remember { mutableStateOf<List<VideoItem>>(emptyList()) }
+    var shortsResults by remember { mutableStateOf<List<ShortsItem>>(emptyList()) }
     var videoPlaylistResults by remember { mutableStateOf<List<VideoPlaylist>>(emptyList()) }
     var channelResults by remember {
         mutableStateOf<List<com.ivor.ivormusic.data.SubscribedChannel>>(emptyList())
@@ -319,13 +327,14 @@ fun SearchScreen(
     // Search YouTube/Videos/Artists/Albums/Playlists when query changes.
     // Local-only mode never fetches: the local library filter below is
     // the entire search experience.
-    LaunchedEffect(query, videoMode, selectedCategory, selectedVideoCategory, selectedDateFilter, selectedSort) {
+    LaunchedEffect(query, videoMode, selectedCategory, selectedVideoCategory, selectedDateFilter, selectedSort, shortsEnabled) {
         if (parsedLink != null) {
             // A pasted link is resolved by its own effect below; make sure no
             // stale text-search results linger behind the link result card.
             isLoading = false
             youtubeResults = emptyList()
             videoResults = emptyList()
+            shortsResults = emptyList()
             videoPlaylistResults = emptyList()
             channelResults = emptyList()
             artistResults = emptyList()
@@ -340,6 +349,7 @@ fun SearchScreen(
             // Clear previous results of other types
             youtubeResults = emptyList()
             videoResults = emptyList()
+            shortsResults = emptyList()
             videoPlaylistResults = emptyList()
             channelResults = emptyList()
             artistResults = emptyList()
@@ -352,7 +362,18 @@ fun SearchScreen(
 
             if (videoMode) {
                 when (selectedVideoCategory) {
-                    VideoSearchCategory.VIDEOS -> videoResults = viewModel.searchVideos(query, selectedDateFilter, selectedSort)
+                    VideoSearchCategory.VIDEOS -> {
+                        if (shortsEnabled) {
+                            val videosDeferred = async { viewModel.searchVideos(query, selectedDateFilter, selectedSort) }
+                            val shortsDeferred = async { viewModel.searchShorts(query) }
+                            videoResults = videosDeferred.await()
+                            shortsResults = shortsDeferred.await()
+                        } else {
+                            videoResults = viewModel.searchVideos(query, selectedDateFilter, selectedSort)
+                            shortsResults = emptyList()
+                        }
+                    }
+                    VideoSearchCategory.SHORTS -> shortsResults = viewModel.searchShorts(query)
                     VideoSearchCategory.PLAYLISTS -> videoPlaylistResults = viewModel.searchVideoPlaylists(query)
                     VideoSearchCategory.CHANNELS -> channelResults = viewModel.searchChannels(query)
                 }
@@ -368,6 +389,7 @@ fun SearchScreen(
         } else {
             youtubeResults = emptyList()
             videoResults = emptyList()
+            shortsResults = emptyList()
             videoPlaylistResults = emptyList()
             channelResults = emptyList()
             artistResults = emptyList()
@@ -559,6 +581,7 @@ fun SearchScreen(
                     VideoSearchFilterChips(
                         selectedCategory = selectedVideoCategory,
                         onCategorySelected = { selectedVideoCategory = it },
+                        shortsEnabled = shortsEnabled,
                         modifier = Modifier.padding(horizontal = 20.dp, vertical = 8.dp)
                     )
                 }
@@ -744,6 +767,7 @@ fun SearchScreen(
                                 Spacer(modifier = Modifier.height(16.dp))
                                 Text(
                                     when {
+                                        videoMode && selectedVideoCategory == VideoSearchCategory.SHORTS -> "Searching Shorts..."
                                         videoMode && selectedVideoCategory == VideoSearchCategory.PLAYLISTS -> "Searching Playlists..."
                                         videoMode -> "Searching Videos..."
                                         selectedCategory == SearchCategory.ARTISTS -> "Searching Artists..."
@@ -896,10 +920,11 @@ fun SearchScreen(
                     }
                 }
                 
-                // Video Mode Results: the Videos/Playlists toggle above decides
-                // which search ran, so only one of these lists is ever populated
+                // Video Mode Results: the Videos/Shorts/Playlists/Channels toggle above decides
+                // which search ran, and the Videos view embeds a Shorts shelf
                 videoMode && (
                     videoResults.isNotEmpty() ||
+                        shortsResults.isNotEmpty() ||
                         videoPlaylistResults.isNotEmpty() ||
                         channelResults.isNotEmpty()
                     ) -> {
@@ -955,7 +980,45 @@ fun SearchScreen(
                         }
                     }
 
-                    // Video Search Results Section
+                    // Dedicated Shorts Search Category Results
+                    if (selectedVideoCategory == VideoSearchCategory.SHORTS && shortsResults.isNotEmpty()) {
+                        item {
+                            ResultHeader(
+                                title = "Shorts",
+                                count = shortsResults.size,
+                                icon = Icons.Rounded.Bolt,
+                                color = MaterialTheme.colorScheme.primary,
+                                textColor = textColor,
+                                secondaryTextColor = secondaryTextColor
+                            )
+                        }
+                        val shortsPairs = shortsResults.chunked(2)
+                        itemsIndexed(shortsPairs) { rowIndex, pair ->
+                            Row(
+                                modifier = Modifier
+                                    .fillMaxWidth()
+                                    .padding(horizontal = 16.dp, vertical = 4.dp),
+                                horizontalArrangement = Arrangement.spacedBy(10.dp)
+                            ) {
+                                pair.forEachIndexed { colIndex, item ->
+                                    val flatIndex = rowIndex * 2 + colIndex
+                                    ShortsResultCard(
+                                        item = item,
+                                        onClick = {
+                                            viewModel.addToSearchHistory(query)
+                                            onOpenShorts(shortsResults, flatIndex)
+                                        },
+                                        modifier = Modifier.weight(1f)
+                                    )
+                                }
+                                if (pair.size == 1) {
+                                    Spacer(modifier = Modifier.weight(1f))
+                                }
+                            }
+                        }
+                    }
+
+                    // Video Search Results Section (with inline Shorts carousel)
                     if (videoResults.isNotEmpty()) {
                         item {
                             Row(
@@ -995,8 +1058,35 @@ fun SearchScreen(
                             }
                         }
 
-                        // Display video results; long-press opens the save sheet
-                        itemsIndexed(videoResults) { index, video ->
+                        val leadingVideos = if (shortsResults.isEmpty()) videoResults else videoResults.take(2)
+                        val trailingVideos = if (shortsResults.isEmpty()) emptyList() else videoResults.drop(2)
+
+                        // Display leading video results
+                        itemsIndexed(leadingVideos) { index, video ->
+                            VideoCard(
+                                video = video,
+                                onClick = { onVideoClick(video) },
+                                onLongClick = { onVideoLongPress(video) },
+                                modifier = Modifier.padding(horizontal = 16.dp, vertical = 8.dp)
+                            )
+                        }
+
+                        // Shorts Carousel Shelf inside Video results (matching standard YouTube feed)
+                        if (shortsResults.isNotEmpty() && selectedVideoCategory == VideoSearchCategory.VIDEOS) {
+                            item {
+                                ShortsShelf(
+                                    shorts = shortsResults,
+                                    onShortClick = { index ->
+                                        viewModel.addToSearchHistory(query)
+                                        onOpenShorts(shortsResults, index)
+                                    },
+                                    modifier = Modifier.padding(vertical = 8.dp)
+                                )
+                            }
+                        }
+
+                        // Display trailing video results
+                        itemsIndexed(trailingVideos) { index, video ->
                             VideoCard(
                                 video = video,
                                 onClick = { onVideoClick(video) },
@@ -1013,6 +1103,18 @@ fun SearchScreen(
                                 cardColor = cardColor,
                                 accentColor = primaryColor,
                                 secondaryTextColor = secondaryTextColor
+                            )
+                        }
+                    } else if (selectedVideoCategory == VideoSearchCategory.VIDEOS && shortsResults.isNotEmpty()) {
+                        // If no standard videos returned but shorts were found
+                        item {
+                            ShortsShelf(
+                                shorts = shortsResults,
+                                onShortClick = { index ->
+                                    viewModel.addToSearchHistory(query)
+                                    onOpenShorts(shortsResults, index)
+                                },
+                                modifier = Modifier.padding(vertical = 8.dp)
                             )
                         }
                     }
@@ -1660,7 +1762,7 @@ enum class SearchCategory {
 }
 
 enum class VideoSearchCategory {
-    VIDEOS, PLAYLISTS, CHANNELS
+    VIDEOS, SHORTS, PLAYLISTS, CHANNELS
 }
 
 @OptIn(ExperimentalMaterial3ExpressiveApi::class)
@@ -1668,14 +1770,19 @@ enum class VideoSearchCategory {
 fun VideoSearchFilterChips(
     selectedCategory: VideoSearchCategory,
     onCategorySelected: (VideoSearchCategory) -> Unit,
+    shortsEnabled: Boolean = true,
     modifier: Modifier = Modifier
 ) {
+    val categories = remember(shortsEnabled) {
+        if (shortsEnabled) VideoSearchCategory.entries
+        else VideoSearchCategory.entries.filter { it != VideoSearchCategory.SHORTS }
+    }
     // Same M3 Expressive connected button group as the music-mode chips
     Row(
         modifier = modifier.fillMaxWidth(),
         horizontalArrangement = Arrangement.spacedBy(androidx.compose.material3.ButtonGroupDefaults.ConnectedSpaceBetween)
     ) {
-        VideoSearchCategory.entries.forEachIndexed { index, category ->
+        categories.forEachIndexed { index, category ->
             val selected = category == selectedCategory
             androidx.compose.material3.ToggleButton(
                 checked = selected,
@@ -1685,15 +1792,78 @@ fun VideoSearchFilterChips(
                     .height(44.dp),
                 shapes = when (index) {
                     0 -> androidx.compose.material3.ButtonGroupDefaults.connectedLeadingButtonShapes()
-                    VideoSearchCategory.entries.lastIndex -> androidx.compose.material3.ButtonGroupDefaults.connectedTrailingButtonShapes()
+                    categories.lastIndex -> androidx.compose.material3.ButtonGroupDefaults.connectedTrailingButtonShapes()
                     else -> androidx.compose.material3.ButtonGroupDefaults.connectedMiddleButtonShapes()
                 },
                 contentPadding = PaddingValues(horizontal = 8.dp)
             ) {
                 Text(
-                    category.name.lowercase().capitalize(),
+                    category.name.lowercase().replaceFirstChar { it.uppercase() },
                     style = MaterialTheme.typography.labelLarge,
                     fontWeight = if (selected) FontWeight.Bold else FontWeight.Medium,
+                    maxLines = 1
+                )
+            }
+        }
+    }
+}
+
+/**
+ * A dedicated Shorts result card used for grid presentation in the Shorts search category.
+ */
+@Composable
+fun ShortsResultCard(
+    item: ShortsItem,
+    onClick: () -> Unit,
+    modifier: Modifier = Modifier
+) {
+    Box(
+        modifier = modifier
+            .aspectRatio(9f / 16f)
+            .clip(RoundedCornerShape(16.dp))
+            .background(MaterialTheme.colorScheme.surfaceContainerHigh)
+            .clickable(onClick = onClick)
+    ) {
+        AsyncImage(
+            model = item.portraitThumbnailUrl,
+            contentDescription = item.title,
+            modifier = Modifier.fillMaxSize(),
+            contentScale = ContentScale.Crop
+        )
+
+        Box(
+            modifier = Modifier
+                .fillMaxWidth()
+                .height(96.dp)
+                .align(Alignment.BottomCenter)
+                .background(
+                    Brush.verticalGradient(
+                        colors = listOf(Color.Transparent, Color.Black.copy(alpha = 0.75f))
+                    )
+                )
+        )
+
+        Column(
+            modifier = Modifier
+                .align(Alignment.BottomStart)
+                .padding(10.dp)
+        ) {
+            if (item.title.isNotBlank()) {
+                Text(
+                    text = item.title,
+                    style = MaterialTheme.typography.labelMedium,
+                    fontWeight = FontWeight.SemiBold,
+                    color = Color.White,
+                    maxLines = 2,
+                    overflow = TextOverflow.Ellipsis
+                )
+            }
+            if (item.viewCount.isNotBlank()) {
+                Spacer(modifier = Modifier.height(2.dp))
+                Text(
+                    text = item.viewCount,
+                    style = MaterialTheme.typography.labelSmall,
+                    color = Color.White.copy(alpha = 0.75f),
                     maxLines = 1
                 )
             }

--- a/app/src/main/java/com/ivor/ivormusic/ui/shorts/ShortsPlayerOverlay.kt
+++ b/app/src/main/java/com/ivor/ivormusic/ui/shorts/ShortsPlayerOverlay.kt
@@ -17,6 +17,7 @@ import androidx.compose.animation.scaleIn
 import androidx.compose.animation.scaleOut
 import androidx.compose.foundation.background
 import androidx.compose.foundation.clickable
+import androidx.compose.foundation.gestures.detectTapGestures
 import androidx.compose.foundation.interaction.MutableInteractionSource
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
@@ -39,6 +40,7 @@ import androidx.compose.foundation.pager.rememberPagerState
 import androidx.compose.foundation.shape.CircleShape
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.Favorite
 import androidx.compose.material.icons.automirrored.rounded.ArrowBack
 import androidx.compose.material.icons.outlined.ThumbDown
 import androidx.compose.material.icons.outlined.ThumbUp
@@ -72,7 +74,9 @@ import androidx.compose.runtime.DisposableEffect
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
+import androidx.compose.runtime.key
 import androidx.compose.runtime.mutableFloatStateOf
+import androidx.compose.runtime.mutableLongStateOf
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.rememberCoroutineScope
@@ -85,8 +89,11 @@ import androidx.compose.ui.graphics.Brush
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.graphics.graphicsLayer
 import androidx.compose.ui.graphics.vector.ImageVector
+import androidx.compose.ui.hapticfeedback.HapticFeedbackType
+import androidx.compose.ui.input.pointer.pointerInput
 import androidx.compose.ui.layout.ContentScale
 import androidx.compose.ui.platform.LocalContext
+import androidx.compose.ui.platform.LocalHapticFeedback
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.text.style.TextOverflow
@@ -286,15 +293,34 @@ fun ShortsPlayerOverlay(
         ) { page ->
             val item = shorts[page]
             val isCurrent = page == pagerState.settledPage
+            var doubleTapHeartTrigger by remember(item.videoId) { mutableLongStateOf(0L) }
+            val haptics = LocalHapticFeedback.current
+
+            LaunchedEffect(isCurrent) {
+                if (!isCurrent) {
+                    doubleTapHeartTrigger = 0L
+                }
+            }
 
             Box(
                 modifier = Modifier
                     .fillMaxSize()
                     .background(Color.Black)
-                    .clickable(
-                        interactionSource = remember { MutableInteractionSource() },
-                        indication = null
-                    ) { if (isCurrent) viewModel.togglePlayPause() }
+                    .pointerInput(isCurrent) {
+                        if (!isCurrent) return@pointerInput
+                        detectTapGestures(
+                            onTap = {
+                                viewModel.togglePlayPause()
+                            },
+                            onDoubleTap = {
+                                requireLogin {
+                                    viewModel.like()
+                                    doubleTapHeartTrigger = System.currentTimeMillis()
+                                    haptics.performHapticFeedback(HapticFeedbackType.Confirm)
+                                }
+                            }
+                        )
+                    }
             ) {
                 // Portrait thumbnail behind the surface: visible on
                 // neighbouring pages and while the current one buffers
@@ -320,6 +346,14 @@ fun ShortsPlayerOverlay(
                 }
 
                 if (isCurrent) {
+                    if (doubleTapHeartTrigger > 0L) {
+                        // Double-tap heart burst animation
+                        DoubleTapHeartBurst(
+                            trigger = doubleTapHeartTrigger,
+                            onDismiss = { doubleTapHeartTrigger = 0L },
+                            modifier = Modifier.align(Alignment.Center)
+                        )
+                    }
                     // Buffering: the expressive shape-morphing loader on a
                     // tonal puck so it reads on any video frame
                     AnimatedVisibility(
@@ -574,68 +608,70 @@ fun ShortsPlayerOverlay(
 
             // Standalone round action buttons; each can be hidden in Settings
             val likeStatus = engagement?.likeStatus ?: LikeStatus.INDIFFERENT
-            Column(
-                horizontalAlignment = Alignment.CenterHorizontally,
-                verticalArrangement = Arrangement.spacedBy(14.dp)
-            ) {
-                if (ThemePreferences.SHORTS_ACTION_LIKE !in hiddenActions) {
-                    ShortsAction(
-                        icon = if (likeStatus == LikeStatus.LIKE) Icons.Rounded.ThumbUp
-                            else Icons.Outlined.ThumbUp,
-                        label = engagement?.likeCount ?: "Like",
-                        active = likeStatus == LikeStatus.LIKE,
-                        burstOnActivate = true,
-                        contentDescription = "Like",
-                        onClick = { requireLogin { viewModel.toggleLike() } }
-                    )
-                }
-                if (ThemePreferences.SHORTS_ACTION_DISLIKE !in hiddenActions) {
-                    ShortsAction(
-                        icon = if (likeStatus == LikeStatus.DISLIKE) Icons.Rounded.ThumbDown
-                            else Icons.Outlined.ThumbDown,
-                        label = "Dislike",
-                        active = likeStatus == LikeStatus.DISLIKE,
-                        contentDescription = "Dislike",
-                        onClick = { requireLogin { viewModel.toggleDislike() } }
-                    )
-                }
-                if (ThemePreferences.SHORTS_ACTION_COMMENTS !in hiddenActions) {
-                    ShortsAction(
-                        icon = Icons.Rounded.ChatBubble,
-                        label = "Comments",
-                        contentDescription = "Comments",
-                        onClick = {
-                            viewModel.ensureCommentsLoaded()
-                            showCommentsSheet = true
-                        }
-                    )
-                }
-                if (ThemePreferences.SHORTS_ACTION_SHARE !in hiddenActions) {
-                    ShortsAction(
-                        icon = Icons.Rounded.Share,
-                        label = "Share",
-                        contentDescription = "Share",
-                        onClick = {
-                            val videoId = currentVideo?.videoId ?: return@ShortsAction
-                            val send = Intent(Intent.ACTION_SEND).apply {
-                                type = "text/plain"
-                                putExtra(Intent.EXTRA_TEXT, "https://youtube.com/shorts/$videoId")
+            key(currentVideo?.videoId) {
+                Column(
+                    horizontalAlignment = Alignment.CenterHorizontally,
+                    verticalArrangement = Arrangement.spacedBy(14.dp)
+                ) {
+                    if (ThemePreferences.SHORTS_ACTION_LIKE !in hiddenActions) {
+                        ShortsAction(
+                            icon = if (likeStatus == LikeStatus.LIKE) Icons.Rounded.ThumbUp
+                                else Icons.Outlined.ThumbUp,
+                            label = engagement?.likeCount ?: "Like",
+                            active = likeStatus == LikeStatus.LIKE,
+                            burstOnActivate = true,
+                            contentDescription = "Like",
+                            onClick = { requireLogin { viewModel.toggleLike() } }
+                        )
+                    }
+                    if (ThemePreferences.SHORTS_ACTION_DISLIKE !in hiddenActions) {
+                        ShortsAction(
+                            icon = if (likeStatus == LikeStatus.DISLIKE) Icons.Rounded.ThumbDown
+                                else Icons.Outlined.ThumbDown,
+                            label = "Dislike",
+                            active = likeStatus == LikeStatus.DISLIKE,
+                            contentDescription = "Dislike",
+                            onClick = { requireLogin { viewModel.toggleDislike() } }
+                        )
+                    }
+                    if (ThemePreferences.SHORTS_ACTION_COMMENTS !in hiddenActions) {
+                        ShortsAction(
+                            icon = Icons.Rounded.ChatBubble,
+                            label = "Comments",
+                            contentDescription = "Comments",
+                            onClick = {
+                                viewModel.ensureCommentsLoaded()
+                                showCommentsSheet = true
                             }
-                            context.startActivity(Intent.createChooser(send, "Share Short"))
-                        }
-                    )
-                }
-                if (ThemePreferences.SHORTS_ACTION_NOT_INTERESTED !in hiddenActions) {
-                    ShortsAction(
-                        icon = Icons.Rounded.NotInterested,
-                        label = "Not interested",
-                        contentDescription = "Not interested",
-                        // Opens a chooser rather than acting straight away: this
-                        // button sits in a rail the thumb rests on while
-                        // swiping, and a one-tap irreversible-looking dismissal
-                        // there would go off by accident constantly.
-                        onClick = { showDismissSheet = true }
-                    )
+                        )
+                    }
+                    if (ThemePreferences.SHORTS_ACTION_SHARE !in hiddenActions) {
+                        ShortsAction(
+                            icon = Icons.Rounded.Share,
+                            label = "Share",
+                            contentDescription = "Share",
+                            onClick = {
+                                val videoId = currentVideo?.videoId ?: return@ShortsAction
+                                val send = Intent(Intent.ACTION_SEND).apply {
+                                    type = "text/plain"
+                                    putExtra(Intent.EXTRA_TEXT, "https://youtube.com/shorts/$videoId")
+                                }
+                                context.startActivity(Intent.createChooser(send, "Share Short"))
+                            }
+                        )
+                    }
+                    if (ThemePreferences.SHORTS_ACTION_NOT_INTERESTED !in hiddenActions) {
+                        ShortsAction(
+                            icon = Icons.Rounded.NotInterested,
+                            label = "Not interested",
+                            contentDescription = "Not interested",
+                            // Opens a chooser rather than acting straight away: this
+                            // button sits in a rail the thumb rests on while
+                            // swiping, and a one-tap irreversible-looking dismissal
+                            // there would go off by accident constantly.
+                            onClick = { showDismissSheet = true }
+                        )
+                    }
                 }
             }
         }
@@ -726,14 +762,10 @@ private fun ShortsAction(
 ) {
     val iconScale = remember { Animatable(1f) }
     val burstProgress = remember { Animatable(0f) }
-    var isInitial by remember { mutableStateOf(true) }
+    var prevActive by remember { mutableStateOf(active) }
 
     LaunchedEffect(active) {
-        if (isInitial) {
-            isInitial = false
-            return@LaunchedEffect
-        }
-        if (active) {
+        if (active && !prevActive) {
             launch {
                 iconScale.snapTo(0.5f)
                 iconScale.animateTo(
@@ -750,6 +782,7 @@ private fun ShortsAction(
                 burstProgress.snapTo(0f)
             }
         }
+        prevActive = active
     }
 
     val containerColor by animateColorAsState(
@@ -915,6 +948,115 @@ private fun ShortsDismissRow(
                     overflow = TextOverflow.Ellipsis
                 )
             }
+        }
+    }
+}
+
+/**
+ * Expressive heart pop animation shown in the center of the Short when double-tapped.
+ *
+ * Starts with a springy scale-up overshoot and burst flash, holds momentarily,
+ * then drifts up and fades out cleanly.
+ */
+@OptIn(ExperimentalMaterial3ExpressiveApi::class)
+@Composable
+private fun DoubleTapHeartBurst(
+    trigger: Long,
+    modifier: Modifier = Modifier,
+    onDismiss: () -> Unit = {}
+) {
+    val scale = remember { Animatable(0f) }
+    val alpha = remember { Animatable(0f) }
+    val offsetY = remember { Animatable(0f) }
+    val burstProgress = remember { Animatable(0f) }
+
+    LaunchedEffect(trigger) {
+        if (trigger <= 0L) return@LaunchedEffect
+        scale.snapTo(0f)
+        alpha.snapTo(1f)
+        offsetY.snapTo(0f)
+        burstProgress.snapTo(0f)
+
+        launch {
+            burstProgress.snapTo(0.01f)
+            burstProgress.animateTo(
+                targetValue = 1f,
+                animationSpec = tween(durationMillis = 400, easing = FastOutSlowInEasing)
+            )
+            burstProgress.snapTo(0f)
+        }
+        launch {
+            scale.animateTo(
+                targetValue = 1f,
+                animationSpec = spring(
+                    dampingRatio = Spring.DampingRatioMediumBouncy,
+                    stiffness = Spring.StiffnessMedium
+                )
+            )
+            delay(350)
+            launch {
+                offsetY.animateTo(
+                    targetValue = -40f,
+                    animationSpec = tween(durationMillis = 300, easing = FastOutSlowInEasing)
+                )
+            }
+            launch {
+                scale.animateTo(
+                    targetValue = 0.85f,
+                    animationSpec = tween(durationMillis = 300, easing = FastOutSlowInEasing)
+                )
+            }
+            alpha.animateTo(
+                targetValue = 0f,
+                animationSpec = tween(durationMillis = 300, easing = FastOutSlowInEasing)
+            )
+            onDismiss()
+        }
+    }
+
+    if (alpha.value > 0f && scale.value > 0f) {
+        val density = androidx.compose.ui.platform.LocalDensity.current.density
+        Box(
+            modifier = modifier
+                .graphicsLayer {
+                    translationY = offsetY.value * density
+                    scaleX = scale.value
+                    scaleY = scale.value
+                    this.alpha = alpha.value
+                },
+            contentAlignment = Alignment.Center
+        ) {
+            val p = burstProgress.value
+            if (p > 0f) {
+                Box(
+                    modifier = Modifier
+                        .size(160.dp)
+                        .graphicsLayer {
+                            scaleX = 0.4f + p * 1.3f
+                            scaleY = 0.4f + p * 1.3f
+                            this.alpha = (1f - p) * alpha.value
+                        }
+                        .clip(MaterialShapes.Burst.toShape())
+                        .background(MaterialTheme.colorScheme.primary.copy(alpha = 0.4f))
+                )
+            }
+            // Ambient soft glow behind heart for contrast on any frame
+            Box(
+                modifier = Modifier
+                    .size(110.dp)
+                    .clip(CircleShape)
+                    .background(Color.Black.copy(alpha = 0.25f * alpha.value))
+            )
+            Icon(
+                imageVector = Icons.Filled.Favorite,
+                contentDescription = null,
+                tint = MaterialTheme.colorScheme.primary,
+                modifier = Modifier
+                    .size(96.dp)
+                    .graphicsLayer {
+                        rotationZ = -6f
+                    }
+            )
         }
     }
 }

--- a/app/src/main/java/com/ivor/ivormusic/ui/shorts/ShortsPlayerViewModel.kt
+++ b/app/src/main/java/com/ivor/ivormusic/ui/shorts/ShortsPlayerViewModel.kt
@@ -219,6 +219,22 @@ class ShortsPlayerViewModel(application: android.app.Application) : AndroidViewM
         synchronized(watchNextCache) { watchNextCache[videoId] = data }
     }
 
+    private fun updateCachedEngagement(videoId: String, engagement: VideoEngagement) {
+        synchronized(watchNextCache) {
+            val cached = watchNextCache[videoId]
+            if (cached != null) {
+                watchNextCache[videoId] = cached.copy(engagement = engagement)
+            } else {
+                val videoItem = _currentVideo.value?.takeIf { it.videoId == videoId }
+                watchNextCache[videoId] = com.ivor.ivormusic.data.WatchNextData(
+                    engagement = engagement,
+                    updatedVideoItem = videoItem,
+                    relatedVideos = emptyList()
+                )
+            }
+        }
+    }
+
     /**
      * Warm the caches around [index]: stream URLs for the next
      * [STREAM_PREFETCH_AHEAD] Shorts plus the previous one, watch-next for
@@ -644,6 +660,14 @@ class ShortsPlayerViewModel(application: android.app.Application) : AndroidViewM
         _playbackError.value = null
         _currentVideo.value = item.toVideoItem()
         resetEngagementState()
+        // Instantly restore cached engagement if available (avoids like button flickering to unliked)
+        val cached = cachedWatchNext(item.videoId)
+        if (cached != null) {
+            _engagement.value = cached.engagement
+            if (cached.updatedVideoItem != null) {
+                _currentVideo.value = cached.updatedVideoItem
+            }
+        }
 
         // Phase 1: streams only, playback ASAP (same two-phase pattern and
         // 15s stuck-buffering guard as VideoPlayerViewModel.playVideo).
@@ -704,7 +728,21 @@ class ShortsPlayerViewModel(application: android.app.Application) : AndroidViewM
                     ?: youtubeRepository.getWatchNextData(item.videoId, item.toVideoItem())
                         .also { cacheWatchNext(item.videoId, it) }
                 if (_currentIndex.value != index) return@launch
-                _engagement.value = watchNext.engagement
+                val currentEng = _engagement.value
+                val resolvedEng = if (currentEng != null && currentEng.videoId == item.videoId) {
+                    val baseEng = watchNext.engagement ?: currentEng
+                    baseEng.copy(
+                        likeStatus = currentEng.likeStatus,
+                        likeCount = currentEng.likeCount ?: baseEng.likeCount,
+                        isSubscribed = currentEng.isSubscribed
+                    )
+                } else {
+                    watchNext.engagement
+                }
+                _engagement.value = resolvedEng
+                if (resolvedEng != null) {
+                    updateCachedEngagement(item.videoId, resolvedEng)
+                }
                 if (watchNext.updatedVideoItem != null) {
                     _currentVideo.value = watchNext.updatedVideoItem
                 }
@@ -837,8 +875,19 @@ class ShortsPlayerViewModel(application: android.app.Application) : AndroidViewM
         }
     }
 
+    /** Like the video, or remove the like if already liked. Optimistic with rollback. */
     fun toggleLike() = rate { current ->
         if (current == LikeStatus.LIKE) LikeStatus.INDIFFERENT else LikeStatus.LIKE
+    }
+
+    /**
+     * Like the Short unconditionally (used for double-tap to like).
+     * If already liked, this is a no-op.
+     */
+    fun like() {
+        val current = _engagement.value
+        if (current != null && current.likeStatus == LikeStatus.LIKE) return
+        rate { LikeStatus.LIKE }
     }
 
     fun toggleDislike() = rate { current ->
@@ -846,14 +895,77 @@ class ShortsPlayerViewModel(application: android.app.Application) : AndroidViewM
     }
 
     private fun rate(target: (LikeStatus) -> LikeStatus) {
-        val current = _engagement.value ?: return
-        val newStatus = target(current.likeStatus)
-        _engagement.value = current.copy(likeStatus = newStatus)
+        val current = _engagement.value ?: run {
+            val video = _currentVideo.value ?: return
+            VideoEngagement(
+                videoId = video.videoId,
+                likeCount = null,
+                likeStatus = LikeStatus.INDIFFERENT,
+                channelId = video.channelId,
+                isSubscribed = false,
+                subscriberCountText = null,
+                commentsToken = null
+            )
+        }
+        val oldStatus = current.likeStatus
+        val newStatus = target(oldStatus)
+        if (oldStatus == newStatus) return
+
+        val delta = when {
+            newStatus == LikeStatus.LIKE -> 1
+            oldStatus == LikeStatus.LIKE -> -1
+            else -> 0
+        }
+        val newLikeCount = if (delta != 0) adjustLikeCount(current.likeCount, delta) else current.likeCount
+
+        val updatedEngagement = current.copy(
+            likeStatus = newStatus,
+            likeCount = newLikeCount
+        )
+        _engagement.value = updatedEngagement
+        updateCachedEngagement(current.videoId, updatedEngagement)
         viewModelScope.launch {
             val ok = youtubeRepository.rateVideo(current.videoId, newStatus)
             if (!ok && _engagement.value?.videoId == current.videoId) {
-                _engagement.value = _engagement.value?.copy(likeStatus = current.likeStatus)
+                val reverted = _engagement.value?.copy(
+                    likeStatus = current.likeStatus,
+                    likeCount = current.likeCount
+                )
+                _engagement.value = reverted
+                if (reverted != null) updateCachedEngagement(current.videoId, reverted)
             }
+        }
+    }
+
+    private fun adjustLikeCount(countStr: String?, delta: Int): String? {
+        if (countStr.isNullOrBlank()) {
+            return if (delta > 0) "1" else null
+        }
+        val trimmed = countStr.trim()
+        val multiplier = when {
+            trimmed.endsWith("B", ignoreCase = true) -> 1_000_000_000.0
+            trimmed.endsWith("M", ignoreCase = true) -> 1_000_000.0
+            trimmed.endsWith("K", ignoreCase = true) -> 1_000.0
+            else -> 1.0
+        }
+        val numPart = if (multiplier > 1.0) trimmed.dropLast(1).trim() else trimmed
+        val parsed = numPart.toDoubleOrNull() ?: return countStr
+        val totalCount = (parsed * multiplier + delta).coerceAtLeast(0.0)
+        return when {
+            totalCount >= 1_000_000_000 -> {
+                val v = totalCount / 1_000_000_000.0
+                if (v >= 10.0 || v % 1.0 == 0.0) "${v.toLong()}B" else String.format(java.util.Locale.US, "%.1fB", v)
+            }
+            totalCount >= 1_000_000 -> {
+                val v = totalCount / 1_000_000.0
+                if (v >= 10.0 || v % 1.0 == 0.0) "${v.toLong()}M" else String.format(java.util.Locale.US, "%.1fM", v)
+            }
+            totalCount >= 1_000 -> {
+                val v = totalCount / 1_000.0
+                if (v >= 10.0 || v % 1.0 == 0.0) "${v.toLong()}K" else String.format(java.util.Locale.US, "%.1fK", v)
+            }
+            totalCount == 0.0 -> "0"
+            else -> totalCount.toLong().toString()
         }
     }
 
@@ -869,13 +981,15 @@ class ShortsPlayerViewModel(application: android.app.Application) : AndroidViewM
 
         val writesRemote =
             subscriptionActions.resolveTarget() != com.ivor.ivormusic.data.SubscriptionStore.LOCAL
-        _engagement.value = current.copy(
+        val updated = current.copy(
             isSubscribed = when {
                 !subscribe -> false
                 writesRemote -> true
                 else -> current.isSubscribed
             }
         )
+        _engagement.value = updated
+        updateCachedEngagement(current.videoId, updated)
         viewModelScope.launch {
             val ok = subscriptionActions.setSubscribed(
                 channel = com.ivor.ivormusic.data.LocalSubscription(
@@ -887,7 +1001,9 @@ class ShortsPlayerViewModel(application: android.app.Application) : AndroidViewM
                 remotelySubscribed = current.isSubscribed
             )
             if (!ok && _engagement.value?.videoId == current.videoId) {
-                _engagement.value = _engagement.value?.copy(isSubscribed = current.isSubscribed)
+                val reverted = _engagement.value?.copy(isSubscribed = current.isSubscribed)
+                _engagement.value = reverted
+                if (reverted != null) updateCachedEngagement(current.videoId, reverted)
             }
         }
     }


### PR DESCRIPTION
  ## What this changes                                                                                                                                                          
                                                                                                                                                                                  
    Adds YouTube Shorts discovery to search results and an expressive double-tap-to-like experience in the Shorts player overlay:                                                 
    1. **Search Integration**:                                                                                                                                                    
       - Added an inline horizontal **Shorts shelf carousel** within standard video search results (placed after the top two video cards, matching YouTube layout).               
       - Added a dedicated **Shorts category filter chip** in video search that displays a 2-column grid of vertical 9:16 Shorts result cards (`ShortsResultCard`).               
    2. **Double-Tap to Like & Expressive Motion**:                                                                                                                                
       - Double-tapping anywhere on the Shorts player triggers an instant like with haptic feedback.                                                                              
       - Renders a floating, spring-animated heart with scale pop, slight rotational wiggle, and fade-out positioned at the touch coordinate.                                     
       - Adds an animated bouncy scale to the action bar like icon.                                                                                                               
       - Features optimistic like count formatting (supporting K/M/B suffixes) with automatic rollback on network failure, and engagement state caching across vertical swipe     
  transitions to eliminate UI flicker.                                                                                                                                            
                                                                                                                                                                                  
    ## Why                                                                                                                                                                        
                                                                                                                                                                                  
    - **Discovery**: Previously, searching in video mode only surfaced standard landscape videos, leaving YouTube Shorts inaccessible from search without manual channel browsing.
    - **Interactivity**: Liking Shorts required reaching the small action button in the right gutter. Double-tapping is the standard, thumb-friendly interaction expected in      
  vertical video feeds.                                                                                                                                                           
                                                                                                                                                                                  
    ## States handled                                                                                                                                                             
                                                                                                                                                                                  
    - **Loading**: Shimmer / placeholder surfaces on search cards while metadata loads; instant optimistic UI updates on double-tap while network requests execute in the         
  background.                                                                                                                                                                     
    - **Empty**: Gracefully displays empty search states when no Shorts match the query.                                                                                          
    - **Error / offline**: If the rate request fails remotely, the like status and counter automatically revert to their prior state; search failures fall back gracefully without
  crashing.                                                                                                                                                                       
    - **Signed out**: Double-tap updates local engagement and rolls back cleanly if the backend rejects unauthorized actions.                                                     
    - **Long titles, missing thumbnail, no artwork colors**: `ShortsResultCard` caps titles to 2 lines with ellipsis over a scrim gradient to ensure high contrast against any    
  thumbnail; missing thumbnails fall back to `surfaceContainerHigh`.                                                                                                              
                                                                                                                                                                                  
    ## Deliberately not done                                                                                                                                                      
                                                                                                                                                                                  
    - Double-tapping a Short that is already liked plays the heart animation and haptic pulse for tactile feedback, but remains idempotent (does not un-like or double-increment  
  the counter). Un-liking is done via the action bar button.                                                                                                                      
                                                                                                                                                                                  
    ## Checklist                                                                                                                                                                  
                                                                                                                                                                                  
    - [x] Builds with `./gradlew assembleDebug`                                                                                                                                   
    - [x] Run on a device or emulator, not just compiled                                                                                                                          
    - [x] No hardcoded colors; everything resolves through `ColorScheme`                                                                                                          
    - [x] Material 3 Expressive components used before standard M3, springs for touch-driven motion                                                                               
    - [x] The signed-out path still works                                                                                                                                         
                                                                                                                                                                                  
    ### If this touches one of these areas                                                                                                                                        
                                                                                                                                                                                  
    - [x] **InnerTube parser change** probed against a live response, not written from memory, with the month and year noted in the KDoc                                          
    - [x] No cookie dumps, response JSON, or `.probe/` contents committed                                                                                                         
