### PR TITLE
Fix Up Next video metadata

### DIFF
--- a/app/src/main/java/com/ivor/ivormusic/data/LockupVideoMetadata.kt
+++ b/app/src/main/java/com/ivor/ivormusic/data/LockupVideoMetadata.kt
@@ -1,0 +1,54 @@
+package com.ivor.ivormusic.data
+
+internal data class LockupVideoStats(
+    val viewCount: String = "",
+    val uploadedDate: String = ""
+)
+
+/**
+ * Classifies the statistics row from a modern video lockup.
+ *
+ * YouTube currently sends compact sibling parts such as `263K` and `1h ago`,
+ * but older and accessibility-rich variants still say `263K views` and
+ * `1 hour ago`. Explicit labels win; otherwise the stable row order is views
+ * followed by upload date. Verified against live WEB /next responses August
+ * 2026.
+ */
+internal fun parseLockupVideoStats(parts: List<Pair<String, String?>>): LockupVideoStats {
+    var viewCount = ""
+    var uploadedDate = ""
+    val unclassified = mutableListOf<String>()
+
+    parts.forEach { (content, accessibilityLabel) ->
+        content.split('•')
+            .map { it.trim() }
+            .filter { value -> value.any { it.isLetterOrDigit() } }
+            .forEach { value ->
+                val searchable = "$value ${accessibilityLabel.orEmpty()}"
+                when {
+                    searchable.contains("view", ignoreCase = true) ||
+                        searchable.contains("watching", ignoreCase = true) -> {
+                        if (viewCount.isBlank()) viewCount = value
+                    }
+                    value.isUploadDateText() -> {
+                        if (uploadedDate.isBlank()) uploadedDate = value
+                    }
+                    else -> unclassified += value
+                }
+            }
+    }
+
+    unclassified.forEach { value ->
+        when {
+            viewCount.isBlank() -> viewCount = value
+            uploadedDate.isBlank() -> uploadedDate = value
+        }
+    }
+    return LockupVideoStats(viewCount, uploadedDate)
+}
+
+private fun String.isUploadDateText(): Boolean =
+    contains("ago", ignoreCase = true) ||
+        startsWith("streamed ", ignoreCase = true) ||
+        startsWith("premiered ", ignoreCase = true) ||
+        matches(Regex("""\d+\s*(?:s|m|h|d|w|mo|y)\s+ago""", RegexOption.IGNORE_CASE))

--- a/app/src/main/java/com/ivor/ivormusic/data/YouTubeRepository.kt
+++ b/app/src/main/java/com/ivor/ivormusic/data/YouTubeRepository.kt
@@ -4095,24 +4095,16 @@ class YouTubeRepository(private val context: Context) {
 
              fun absorbVideoStats(parts: org.json.JSONArray?) {
                  if (parts == null) return
-                 for (i in 0 until parts.length()) {
-                     val raw = parts.optJSONObject(i)
-                         ?.optJSONObject("text")
-                         ?.optString("content")
-                         .orEmpty()
-                     raw.split('•')
-                         .map { it.trim() }
-                         .filter { value -> value.any { it.isLetterOrDigit() } }
-                         .forEach { value ->
-                             when {
-                                 value.contains("view", ignoreCase = true) ||
-                                     value.contains("watching", ignoreCase = true) -> {
-                                     if (viewCount.isBlank()) viewCount = value
-                                 }
-                                 uploadDate.isBlank() -> uploadDate = value
-                             }
-                         }
-                 }
+                 val stats = parseLockupVideoStats(
+                     (0 until parts.length()).map { index ->
+                         val part = parts.optJSONObject(index)
+                         val text = part?.optJSONObject("text")
+                         text?.optString("content").orEmpty() to
+                             part?.optString("accessibilityLabel")?.takeIf { it.isNotBlank() }
+                     }
+                 )
+                 if (viewCount.isBlank()) viewCount = stats.viewCount
+                 if (uploadDate.isBlank()) uploadDate = stats.uploadedDate
              }
              
              if (metadataRows != null && metadataRows.length() > 0) {
@@ -4120,7 +4112,16 @@ class YouTubeRepository(private val context: Context) {
                  if (firstRowParts != null && firstRowParts.length() > 0) {
                      val textObj = firstRowParts.optJSONObject(0)?.optJSONObject("text")
                      val firstText = textObj?.optString("content").orEmpty()
-                     val firstRowIsStats = firstText.contains("view", ignoreCase = true) ||
+                     val firstRowStats = parseLockupVideoStats(
+                         (0 until firstRowParts.length()).map { index ->
+                             val part = firstRowParts.optJSONObject(index)
+                             val text = part?.optJSONObject("text")
+                             text?.optString("content").orEmpty() to
+                                 part?.optString("accessibilityLabel")?.takeIf { it.isNotBlank() }
+                         }
+                     )
+                     val firstRowIsStats = firstRowStats.uploadedDate.isNotBlank() ||
+                         firstText.contains("view", ignoreCase = true) ||
                          firstText.contains("watching", ignoreCase = true)
 
                      if (firstRowIsStats) {

--- a/app/src/main/java/com/ivor/ivormusic/ui/video/VideoPlayerScreen.kt
+++ b/app/src/main/java/com/ivor/ivormusic/ui/video/VideoPlayerScreen.kt
@@ -2553,11 +2553,17 @@ fun VideoInfoSection(
                                 color = MaterialTheme.colorScheme.onSurfaceVariant
                             )
                             Spacer(Modifier.height(2.dp))
-                            Text(
-                                text = relatedVideo.viewCount + " • " + (relatedVideo.uploadedDate ?: ""),
-                                style = MaterialTheme.typography.labelSmall,
-                                color = MaterialTheme.colorScheme.onSurfaceVariant
-                            )
+                            val stats = listOfNotNull(
+                                relatedVideo.viewCount.takeIf { it.isNotBlank() },
+                                relatedVideo.uploadedDate?.takeIf { it.isNotBlank() }
+                            ).joinToString(" • ")
+                            if (stats.isNotBlank()) {
+                                Text(
+                                    text = stats,
+                                    style = MaterialTheme.typography.labelSmall,
+                                    color = MaterialTheme.colorScheme.onSurfaceVariant
+                                )
+                            }
                         }
                     }
                 }

--- a/app/src/test/java/com/ivor/ivormusic/data/LockupVideoMetadataTest.kt
+++ b/app/src/test/java/com/ivor/ivormusic/data/LockupVideoMetadataTest.kt
@@ -1,0 +1,46 @@
+package com.ivor.ivormusic.data
+
+import org.junit.Assert.assertEquals
+import org.junit.Test
+
+class LockupVideoMetadataTest {
+    @Test
+    fun `compact watch-next parts preserve views and upload date`() {
+        val stats = parseLockupVideoStats(
+            listOf("263K" to null, "1h ago" to null)
+        )
+
+        assertEquals("263K", stats.viewCount)
+        assertEquals("1h ago", stats.uploadedDate)
+    }
+
+    @Test
+    fun `legacy combined part remains supported`() {
+        val stats = parseLockupVideoStats(
+            listOf("376K views • 2 days ago" to null)
+        )
+
+        assertEquals("376K views", stats.viewCount)
+        assertEquals("2 days ago", stats.uploadedDate)
+    }
+
+    @Test
+    fun `accessibility label identifies compact view count`() {
+        val stats = parseLockupVideoStats(
+            listOf("575K" to "575 thousand views", "2h ago" to "2 hours ago")
+        )
+
+        assertEquals("575K", stats.viewCount)
+        assertEquals("2h ago", stats.uploadedDate)
+    }
+
+    @Test
+    fun `live watching count is not treated as an upload date`() {
+        val stats = parseLockupVideoStats(
+            listOf("1.2K watching" to null)
+        )
+
+        assertEquals("1.2K watching", stats.viewCount)
+        assertEquals("", stats.uploadedDate)
+    }
+}


### PR DESCRIPTION
## Summary
- parse compact watch-next view counts and upload dates correctly
- retain compatibility with legacy combined metadata rows and accessibility labels
- omit dangling separators when one Up Next metadata field is unavailable

## Verification
- `./gradlew testDebugUnitTest --tests com.ivor.ivormusic.data.LockupVideoMetadataTest`
- `./gradlew compileDebugKotlin`